### PR TITLE
Add buildsystem for Linux

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -10,3 +10,10 @@
 *  Applies to the JSON and CSV files, the documentation and everything else not covered under the artwork license above.
 *  License: MIT
 *  Complete Legal Terms: http://opensource.org/licenses/MIT
+
+#### Linux build
+
+* Applies to files in the linux/ directory
+* License: Apache-2.0
+* Complete Legal Terms: https://www.apache.org/licenses/LICENSE-2.0
+* Forked from https://github.com/googlei18n/noto-emoji

--- a/linux/AUTHORS
+++ b/linux/AUTHORS
@@ -1,0 +1,11 @@
+# This is the official list of Noto authors for copyright
+# purposes.
+# This file is distinct from the CONTRIBUTORS files.
+# See the latter for an explanation.
+
+# Names should be added to this file as:
+# Name or Organization <email address>
+# The email address is not required for organizations.
+
+Google Inc.
+Arjen Nienhuis <a.g.nienhuis@gmail.com>  # SVG cleanup

--- a/linux/CONTRIBUTING.md
+++ b/linux/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+Want to contribute? Great! First, read this page (including the small print
+at the end).
+
+### Before you contribute
+Before we can use your code, you must sign the
+[Google Individual Contributor License
+Agreement](https://cla.developers.google.com/about/google-individual) 
+(CLA), which you can do online. The CLA is necessary mainly because you own the
+copyright to your changes, even after your contribution becomes part of our
+codebase, so we need your permission to use and distribute your code. We also
+need to be sure of various other things—for instance that you'll tell us if you
+know that your code infringes on other people's patents. You don't have to sign
+the CLA until after you've submitted your code for review and a member has
+approved it, but you must do it before we can put your code into our codebase.
+Before you start working on a larger contribution, you should get in touch with
+us first through the issue tracker with your idea so that we can help out and
+possibly guide you. Coordinating up front makes it much easier to avoid
+frustration later on.
+
+### Code reviews
+All submissions, including submissions by project members, require review.
+We use Github pull requests for this purpose.
+
+### The small print
+Contributions made by corporations are covered by a different agreement than
+the one above, the [Software Grant and Corporate Contributor License
+Agreement](https://cla.developers.google.com/about/google-corporate).

--- a/linux/CONTRIBUTORS
+++ b/linux/CONTRIBUTORS
@@ -1,0 +1,16 @@
+# People who have agreed to one of the CLAs and can contribute patches.
+# The AUTHORS file lists the copyright holders; this file
+# lists people.  For example, Google employees are listed here
+# but not in AUTHORS, because Google holds the copyright.
+#
+# https://developers.google.com/open-source/cla/individual
+# https://developers.google.com/open-source/cla/corporate
+#
+# Names should be added to this file as:
+#     Name <email address>
+
+Arjen Nienhuis <a.g.nienhuis@gmail.com>
+Behdad Esfahbod <behdad@google.com>
+Doug Felt <dougfelt@google.com>
+Roozbeh Pournader <roozbeh@google.com>
+Victoria Lease <violets@google.com>

--- a/linux/EmojiTwo.tmpl.ttx.tmpl
+++ b/linux/EmojiTwo.tmpl.ttx.tmpl
@@ -1,0 +1,634 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.6">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="null"/>
+    <GlyphID id="2" name="nonmarkingreturn"/>
+    <GlyphID id="3" name="space"/>
+    <GlyphID id="4" name="uni200D"/>
+    <GlyphID id="5" name="uE0030"/>
+    <GlyphID id="6" name="uE0031"/>
+    <GlyphID id="7" name="uE0032"/>
+    <GlyphID id="8" name="uE0033"/>
+    <GlyphID id="9" name="uE0034"/>
+    <GlyphID id="10" name="uE0035"/>
+    <GlyphID id="11" name="uE0036"/>
+    <GlyphID id="12" name="uE0037"/>
+    <GlyphID id="13" name="uE0038"/>
+    <GlyphID id="14" name="uE0039"/>
+    <GlyphID id="15" name="uE0061"/>
+    <GlyphID id="16" name="uE0062"/>
+    <GlyphID id="17" name="uE0063"/>
+    <GlyphID id="18" name="uE0064"/>
+    <GlyphID id="19" name="uE0065"/>
+    <GlyphID id="20" name="uE0066"/>
+    <GlyphID id="21" name="uE0067"/>
+    <GlyphID id="22" name="uE0068"/>
+    <GlyphID id="23" name="uE0069"/>
+    <GlyphID id="24" name="uE006A"/>
+    <GlyphID id="25" name="uE006B"/>
+    <GlyphID id="26" name="uE006C"/>
+    <GlyphID id="27" name="uE006D"/>
+    <GlyphID id="28" name="uE006E"/>
+    <GlyphID id="29" name="uE006F"/>
+    <GlyphID id="30" name="uE0070"/>
+    <GlyphID id="31" name="uE0071"/>
+    <GlyphID id="32" name="uE0072"/>
+    <GlyphID id="33" name="uE0073"/>
+    <GlyphID id="34" name="uE0074"/>
+    <GlyphID id="35" name="uE0075"/>
+    <GlyphID id="36" name="uE0076"/>
+    <GlyphID id="37" name="uE0077"/>
+    <GlyphID id="38" name="uE0078"/>
+    <GlyphID id="39" name="uE0079"/>
+    <GlyphID id="40" name="uE007A"/>
+    <GlyphID id="41" name="uE007F"/>
+    <GlyphID id="42" name="u1F3F4"/>
+    <GlyphID id="43" name="uFE82B"/>
+    <GlyphID id="44" name="u1F1E6"/>
+    <GlyphID id="45" name="u1F1E7"/>
+    <GlyphID id="46" name="u1F1E8"/>
+    <GlyphID id="47" name="u1F1E9"/>
+    <GlyphID id="48" name="u1F1EA"/>
+    <GlyphID id="49" name="u1F1EB"/>
+    <GlyphID id="50" name="u1F1EC"/>
+    <GlyphID id="51" name="u1F1ED"/>
+    <GlyphID id="52" name="u1F1EE"/>
+    <GlyphID id="53" name="u1F1EF"/>
+    <GlyphID id="54" name="u1F1F0"/>
+    <GlyphID id="55" name="u1F1F1"/>
+    <GlyphID id="56" name="u1F1F2"/>
+    <GlyphID id="57" name="u1F1F3"/>
+    <GlyphID id="58" name="u1F1F4"/>
+    <GlyphID id="59" name="u1F1F5"/>
+    <GlyphID id="60" name="u1F1F6"/>
+    <GlyphID id="61" name="u1F1F7"/>
+    <GlyphID id="62" name="u1F1F8"/>
+    <GlyphID id="63" name="u1F1F9"/>
+    <GlyphID id="64" name="u1F1FA"/>
+    <GlyphID id="65" name="u1F1FB"/>
+    <GlyphID id="66" name="u1F1FC"/>
+    <GlyphID id="67" name="u1F1FD"/>
+    <GlyphID id="68" name="u1F1FE"/>
+    <GlyphID id="69" name="u1F1FF"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.39"/>
+    <checkSumAdjustment value="0x4d5a161a"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00001011"/>
+    <unitsPerEm value="2048"/>
+    <created value="Wed May 22 20:00:43 2013"/>
+    <modified value="Wed May 22 20:00:43 2013"/>
+    <xMin value="0"/>
+    <yMin value="-500"/>
+    <xMax value="2550"/>
+    <yMax value="1900"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="8"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1900"/>
+    <descent value="-500"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="2550"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="0"/>
+    <xMaxExtent value="2550"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="4"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="70"/>
+    <maxPoints value="8"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="2"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="1"/>
+    <maxFunctionDefs value="1"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="64"/>
+    <maxSizeOfInstructions value="46"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <version value="4"/>
+    <xAvgCharWidth value="2550"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="1331"/>
+    <ySubscriptYSize value="1433"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="286"/>
+    <ySuperscriptXSize value="1331"/>
+    <ySuperscriptYSize value="1433"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="983"/>
+    <yStrikeoutSize value="102"/>
+    <yStrikeoutPosition value="530"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="6"/>
+      <bProportion value="9"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="GOOG"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="0"/>
+    <usLastCharIndex value="65535"/>
+    <sTypoAscender value="1900"/>
+    <sTypoDescender value="-500"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1900"/>
+    <usWinDescent value="500"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="0"/>
+    <sCapHeight value="1900"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="1"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="2550" lsb="0"/>
+    <mtx name="null" width="0" lsb="0"/>
+    <mtx name="nonmarkingreturn" width="2550" lsb="0"/>
+    <mtx name="space" width="2550" lsb="0"/>
+  </hmtx>
+
+  <vhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1275"/>
+    <descent value="-1275"/>
+    <lineGap value="0"/>
+    <advanceHeightMax value="2500"/>
+    <minTopSideBearing value="0"/>
+    <minBottomSideBearing value="0"/>
+    <yMaxExtent value="2400"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="1"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="2500" tsb="0"/>
+    <mtx name="null" height="0" tsb="0"/>
+    <mtx name="nonmarkingreturn" height="2500" tsb="0"/>
+    <mtx name="space" height="2500" tsb="0"/>
+  </vmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_12 platformID="3" platEncID="10" language="0" format="12" reserved="0" length="1" nGroups="1">
+      <map code="0x0" name="null"/><!-- &lt;control> -->
+      <map code="0xd" name="nonmarkingreturn"/>
+      <map code="0x20" name="space"/>
+    </cmap_format_12>
+  </cmap>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright 2013 Google Inc.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Noto Color Emoji
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      Noto Color Emoji
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Noto Color Emoji
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.39;GOOG;noto-emoji:20170518:009916646ea7
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      NotoColorEmoji
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Noto is a trademark of Google Inc.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Google, Inc.
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Google, Inc.
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Color emoji font using CBDT glyph data.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.google.com/get/noto/
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      http://www.google.com/get/noto/
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://scripts.sil.org/OFL
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="3.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-1244"/>
+    <underlineThickness value="131"/>
+    <isFixedPitch value="1"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+  </post>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="ccmp"/>
+        <Feature>
+          <!-- LookupCount=4 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="2"/>
+          <LookupListIndex index="2" value="3"/>
+          <LookupListIndex index="3" value="4"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=5 -->
+      <Lookup index="0">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <MultipleSubst index="0" Format="1">
+          <Substitution in="u1F1E6" out=""/>
+          <Substitution in="u1F1E7" out=""/>
+          <Substitution in="u1F1E8" out=""/>
+          <Substitution in="u1F1E9" out=""/>
+          <Substitution in="u1F1EA" out=""/>
+          <Substitution in="u1F1EB" out=""/>
+          <Substitution in="u1F1EC" out=""/>
+          <Substitution in="u1F1ED" out=""/>
+          <Substitution in="u1F1EE" out=""/>
+          <Substitution in="u1F1EF" out=""/>
+          <Substitution in="u1F1F0" out=""/>
+          <Substitution in="u1F1F1" out=""/>
+          <Substitution in="u1F1F2" out=""/>
+          <Substitution in="u1F1F3" out=""/>
+          <Substitution in="u1F1F4" out=""/>
+          <Substitution in="u1F1F5" out=""/>
+          <Substitution in="u1F1F6" out=""/>
+          <Substitution in="u1F1F7" out=""/>
+          <Substitution in="u1F1F8" out=""/>
+          <Substitution in="u1F1F9" out=""/>
+          <Substitution in="u1F1FA" out=""/>
+          <Substitution in="u1F1FB" out=""/>
+          <Substitution in="u1F1FC" out=""/>
+          <Substitution in="u1F1FD" out=""/>
+          <Substitution in="u1F1FE" out=""/>
+          <Substitution in="u1F1FF" out=""/>
+          <Substitution in="uE0030" out=""/>
+          <Substitution in="uE0031" out=""/>
+          <Substitution in="uE0032" out=""/>
+          <Substitution in="uE0033" out=""/>
+          <Substitution in="uE0034" out=""/>
+          <Substitution in="uE0035" out=""/>
+          <Substitution in="uE0036" out=""/>
+          <Substitution in="uE0037" out=""/>
+          <Substitution in="uE0038" out=""/>
+          <Substitution in="uE0039" out=""/>
+          <Substitution in="uE0061" out=""/>
+          <Substitution in="uE0062" out=""/>
+          <Substitution in="uE0063" out=""/>
+          <Substitution in="uE0064" out=""/>
+          <Substitution in="uE0065" out=""/>
+          <Substitution in="uE0066" out=""/>
+          <Substitution in="uE0067" out=""/>
+          <Substitution in="uE0068" out=""/>
+          <Substitution in="uE0069" out=""/>
+          <Substitution in="uE006A" out=""/>
+          <Substitution in="uE006B" out=""/>
+          <Substitution in="uE006C" out=""/>
+          <Substitution in="uE006D" out=""/>
+          <Substitution in="uE006E" out=""/>
+          <Substitution in="uE006F" out=""/>
+          <Substitution in="uE0070" out=""/>
+          <Substitution in="uE0071" out=""/>
+          <Substitution in="uE0072" out=""/>
+          <Substitution in="uE0073" out=""/>
+          <Substitution in="uE0074" out=""/>
+          <Substitution in="uE0075" out=""/>
+          <Substitution in="uE0076" out=""/>
+          <Substitution in="uE0077" out=""/>
+          <Substitution in="uE0078" out=""/>
+          <Substitution in="uE0079" out=""/>
+          <Substitution in="uE007A" out=""/>
+        </MultipleSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="6"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ChainContextSubst index="0" Format="2">
+          <Coverage Format="2">
+            <Glyph value="uE0030"/>
+            <Glyph value="uE0031"/>
+            <Glyph value="uE0032"/>
+            <Glyph value="uE0033"/>
+            <Glyph value="uE0034"/>
+            <Glyph value="uE0035"/>
+            <Glyph value="uE0036"/>
+            <Glyph value="uE0037"/>
+            <Glyph value="uE0038"/>
+            <Glyph value="uE0039"/>
+            <Glyph value="uE0061"/>
+            <Glyph value="uE0062"/>
+            <Glyph value="uE0063"/>
+            <Glyph value="uE0064"/>
+            <Glyph value="uE0065"/>
+            <Glyph value="uE0066"/>
+            <Glyph value="uE0067"/>
+            <Glyph value="uE0068"/>
+            <Glyph value="uE0069"/>
+            <Glyph value="uE006A"/>
+            <Glyph value="uE006B"/>
+            <Glyph value="uE006C"/>
+            <Glyph value="uE006D"/>
+            <Glyph value="uE006E"/>
+            <Glyph value="uE006F"/>
+            <Glyph value="uE0070"/>
+            <Glyph value="uE0071"/>
+            <Glyph value="uE0072"/>
+            <Glyph value="uE0073"/>
+            <Glyph value="uE0074"/>
+            <Glyph value="uE0075"/>
+            <Glyph value="uE0076"/>
+            <Glyph value="uE0077"/>
+            <Glyph value="uE0078"/>
+            <Glyph value="uE0079"/>
+            <Glyph value="uE007A"/>
+          </Coverage>
+          <BacktrackClassDef Format="1">
+            <ClassDef glyph="u1F3F4" class="1"/>
+            <ClassDef glyph="uE007F" class="1"/>
+          </BacktrackClassDef>
+          <InputClassDef Format="2">
+            <ClassDef glyph="uE0030" class="2"/>
+            <ClassDef glyph="uE0031" class="2"/>
+            <ClassDef glyph="uE0032" class="2"/>
+            <ClassDef glyph="uE0033" class="2"/>
+            <ClassDef glyph="uE0034" class="2"/>
+            <ClassDef glyph="uE0035" class="2"/>
+            <ClassDef glyph="uE0036" class="2"/>
+            <ClassDef glyph="uE0037" class="2"/>
+            <ClassDef glyph="uE0038" class="2"/>
+            <ClassDef glyph="uE0039" class="2"/>
+            <ClassDef glyph="uE0061" class="2"/>
+            <ClassDef glyph="uE0062" class="2"/>
+            <ClassDef glyph="uE0063" class="2"/>
+            <ClassDef glyph="uE0064" class="2"/>
+            <ClassDef glyph="uE0065" class="2"/>
+            <ClassDef glyph="uE0066" class="2"/>
+            <ClassDef glyph="uE0067" class="2"/>
+            <ClassDef glyph="uE0068" class="2"/>
+            <ClassDef glyph="uE0069" class="2"/>
+            <ClassDef glyph="uE006A" class="2"/>
+            <ClassDef glyph="uE006B" class="2"/>
+            <ClassDef glyph="uE006C" class="2"/>
+            <ClassDef glyph="uE006D" class="2"/>
+            <ClassDef glyph="uE006E" class="2"/>
+            <ClassDef glyph="uE006F" class="2"/>
+            <ClassDef glyph="uE0070" class="2"/>
+            <ClassDef glyph="uE0071" class="2"/>
+            <ClassDef glyph="uE0072" class="2"/>
+            <ClassDef glyph="uE0073" class="2"/>
+            <ClassDef glyph="uE0074" class="2"/>
+            <ClassDef glyph="uE0075" class="2"/>
+            <ClassDef glyph="uE0076" class="2"/>
+            <ClassDef glyph="uE0077" class="2"/>
+            <ClassDef glyph="uE0078" class="2"/>
+            <ClassDef glyph="uE0079" class="2"/>
+            <ClassDef glyph="uE007A" class="2"/>
+          </InputClassDef>
+          <LookAheadClassDef Format="2">
+          </LookAheadClassDef>
+          <!-- ChainSubClassSetCount=3 -->
+          <ChainSubClassSet index="0" empty="1"/>
+          <ChainSubClassSet index="1" empty="1"/>
+          <ChainSubClassSet index="2">
+            <!-- ChainSubClassRuleCount=1 -->
+            <ChainSubClassRule index="0">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="1"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </ChainSubClassRule>
+          </ChainSubClassSet>
+        </ChainContextSubst>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="u1F3F4">
+            <Ligature components="uE007F" glyph="uFE82B"/>
+          </LigatureSet>
+          <LigatureSet glyph="uE007F">
+            <Ligature components="u1F3F4" glyph="uFE82B"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="4">
+        <LookupType value="5"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ContextSubst index="0" Format="2">
+          <Coverage Format="2">
+            <Glyph value="u1F1E6"/>
+            <Glyph value="u1F1E7"/>
+            <Glyph value="u1F1E8"/>
+            <Glyph value="u1F1E9"/>
+            <Glyph value="u1F1EA"/>
+            <Glyph value="u1F1EB"/>
+            <Glyph value="u1F1EC"/>
+            <Glyph value="u1F1ED"/>
+            <Glyph value="u1F1EE"/>
+            <Glyph value="u1F1EF"/>
+            <Glyph value="u1F1F0"/>
+            <Glyph value="u1F1F1"/>
+            <Glyph value="u1F1F2"/>
+            <Glyph value="u1F1F3"/>
+            <Glyph value="u1F1F4"/>
+            <Glyph value="u1F1F5"/>
+            <Glyph value="u1F1F6"/>
+            <Glyph value="u1F1F7"/>
+            <Glyph value="u1F1F8"/>
+            <Glyph value="u1F1F9"/>
+            <Glyph value="u1F1FA"/>
+            <Glyph value="u1F1FB"/>
+            <Glyph value="u1F1FC"/>
+            <Glyph value="u1F1FD"/>
+            <Glyph value="u1F1FE"/>
+            <Glyph value="u1F1FF"/>
+          </Coverage>
+          <ClassDef Format="2">
+            <ClassDef glyph="u1F1E6" class="1"/>
+            <ClassDef glyph="u1F1E7" class="1"/>
+            <ClassDef glyph="u1F1E8" class="1"/>
+            <ClassDef glyph="u1F1E9" class="1"/>
+            <ClassDef glyph="u1F1EA" class="1"/>
+            <ClassDef glyph="u1F1EB" class="1"/>
+            <ClassDef glyph="u1F1EC" class="1"/>
+            <ClassDef glyph="u1F1ED" class="1"/>
+            <ClassDef glyph="u1F1EE" class="1"/>
+            <ClassDef glyph="u1F1EF" class="1"/>
+            <ClassDef glyph="u1F1F0" class="1"/>
+            <ClassDef glyph="u1F1F1" class="1"/>
+            <ClassDef glyph="u1F1F2" class="1"/>
+            <ClassDef glyph="u1F1F3" class="1"/>
+            <ClassDef glyph="u1F1F4" class="1"/>
+            <ClassDef glyph="u1F1F5" class="1"/>
+            <ClassDef glyph="u1F1F6" class="1"/>
+            <ClassDef glyph="u1F1F7" class="1"/>
+            <ClassDef glyph="u1F1F8" class="1"/>
+            <ClassDef glyph="u1F1F9" class="1"/>
+            <ClassDef glyph="u1F1FA" class="1"/>
+            <ClassDef glyph="u1F1FB" class="1"/>
+            <ClassDef glyph="u1F1FC" class="1"/>
+            <ClassDef glyph="u1F1FD" class="1"/>
+            <ClassDef glyph="u1F1FE" class="1"/>
+            <ClassDef glyph="u1F1FF" class="1"/>
+          </ClassDef>
+          <!-- SubClassSetCount=2 -->
+          <SubClassSet index="0" empty="1"/>
+          <SubClassSet index="1">
+            <!-- SubClassRuleCount=1 -->
+            <SubClassRule index="0">
+              <!-- GlyphCount=2 -->
+              <!-- SubstCount=2 -->
+              <Class index="0" value="1"/>
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="5"/>
+              </SubstLookupRecord>
+              <SubstLookupRecord index="1">
+                <SequenceIndex value="1"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </SubClassRule>
+          </SubClassSet>
+        </ContextSubst>
+      </Lookup>
+      <Lookup index="5">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <SingleSubst index="0" Format="1">
+          <Substitution in="u1F1E6" out="uFE82B"/>
+          <Substitution in="u1F1E7" out="uFE82B"/>
+          <Substitution in="u1F1E8" out="uFE82B"/>
+          <Substitution in="u1F1E9" out="uFE82B"/>
+          <Substitution in="u1F1EA" out="uFE82B"/>
+          <Substitution in="u1F1EB" out="uFE82B"/>
+          <Substitution in="u1F1EC" out="uFE82B"/>
+          <Substitution in="u1F1ED" out="uFE82B"/>
+          <Substitution in="u1F1EE" out="uFE82B"/>
+          <Substitution in="u1F1EF" out="uFE82B"/>
+          <Substitution in="u1F1F0" out="uFE82B"/>
+          <Substitution in="u1F1F1" out="uFE82B"/>
+          <Substitution in="u1F1F2" out="uFE82B"/>
+          <Substitution in="u1F1F3" out="uFE82B"/>
+          <Substitution in="u1F1F4" out="uFE82B"/>
+          <Substitution in="u1F1F5" out="uFE82B"/>
+          <Substitution in="u1F1F6" out="uFE82B"/>
+          <Substitution in="u1F1F7" out="uFE82B"/>
+          <Substitution in="u1F1F8" out="uFE82B"/>
+          <Substitution in="u1F1F9" out="uFE82B"/>
+          <Substitution in="u1F1FA" out="uFE82B"/>
+          <Substitution in="u1F1FB" out="uFE82B"/>
+          <Substitution in="u1F1FC" out="uFE82B"/>
+          <Substitution in="u1F1FD" out="uFE82B"/>
+          <Substitution in="u1F1FE" out="uFE82B"/>
+          <Substitution in="u1F1FF" out="uFE82B"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/linux/LICENSE
+++ b/linux/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -12,15 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-EMOJI = NotoColorEmoji
+EMOJI = EmojiTwo
 font: $(EMOJI).ttf
-
-CFLAGS = -std=c99 -Wall -Wextra `pkg-config --cflags --libs cairo`
-LDFLAGS = -lm `pkg-config --libs cairo`
-PNGQUANTDIR := third_party/pngquant
-PNGQUANT := $(PNGQUANTDIR)/pngquant
-PNGQUANTFLAGS = --speed 1 --skip-if-larger --quality 85-95 --force
-IMOPS = -size 136x128 canvas:none -compose copy -gravity center
 
 # zopflipng is better (about 5-10%) but much slower.  it will be used if
 # present.  pass ZOPFLIPNG= as an arg to make to use optipng instead.
@@ -34,66 +27,16 @@ ADD_GLYPHS_FLAGS = -a emoji_aliases.txt
 PUA_ADDER = map_pua_emoji.py
 VS_ADDER = add_vs_cmap.py # from nototools
 
-EMOJI_SRC_DIR := png/128
-FLAGS_SRC_DIR := third_party/region-flags/png
-
 BUILD_DIR := build
-EMOJI_DIR := $(BUILD_DIR)/emoji
-FLAGS_DIR := $(BUILD_DIR)/flags
-RESIZED_FLAGS_DIR := $(BUILD_DIR)/resized_flags
-RENAMED_FLAGS_DIR := $(BUILD_DIR)/renamed_flags
-QUANTIZED_DIR := $(BUILD_DIR)/quantized_pngs
+EMOJI_DIR := ../png/128
 COMPRESSED_DIR := $(BUILD_DIR)/compressed_pngs
 
-# Unknown flag is PUA fe82b
+EMOJI_SRC_NAMES = $(notdir $(wildcard $(EMOJI_DIR)/*.png))
+EMOJI_FILES = $(addprefix $(EMOJI_DIR)/,$(EMOJI_SRC_NAMES)))
+EMOJI_NAMES = $(addprefix emoji_u,$(subst -,_,$(EMOJI_SRC_NAMES)))
 
-LIMITED_FLAGS = CN DE ES FR GB IT JP KR RU US
-SELECTED_FLAGS = AC AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ \
-	BA BB BD BE BF BG BH BI BJ BM BN BO BR BS BT BW BY BZ \
-	CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ \
-	DE DJ DK DM DO DZ \
-	EC EE EG ER ES ET EU \
-	FI FJ FM FO FR \
-	GA GB GD GE GG GH GI GL GM GN GQ GR GT GU GW GY \
-	HK HN HR HT HU \
-	IC ID IE IL IM IN IO IQ IR IS IT \
-	JE JM JO JP \
-	KE KG KH KI KM KN KP KR KW KY KZ \
-	LA LB LC LI LK LR LS LT LU LV LY \
-	MA MC MD ME MG MH MK ML MM MN MO MP MR MS MT MU MV MW MX MY MZ \
-	NA NE NF NG NI NL NO NP NR NU NZ \
-	OM \
-	PA PE PF PG PH PK PL PN PR PS PT PW PY \
-	QA \
-	RO RS RU RW \
-	SA SB SC SD SE SG SH SI SK SL SM SN SO SR SS ST SV SX SY SZ \
-	TA TC TD TG TH TJ TK TL TM TN TO TR TT TV TW TZ \
-	UA UG UN US UY UZ \
-	VA VC VE VG VI VN VU \
-	WS \
-	YE \
-	ZA ZM ZW \
-        GB-ENG GB-SCT GB-WLS
-
-ALL_FLAGS = $(basename $(notdir $(wildcard $(FLAGS_SRC_DIR)/*.png)))
-
-FLAGS = $(SELECTED_FLAGS)
-
-FLAG_NAMES = $(FLAGS:%=%.png)
-FLAG_FILES = $(addprefix $(FLAGS_DIR)/, $(FLAG_NAMES))
-RESIZED_FLAG_FILES = $(addprefix $(RESIZED_FLAGS_DIR)/, $(FLAG_NAMES))
-
-FLAG_GLYPH_NAMES = $(shell ./flag_glyph_name.py $(FLAGS))
-RENAMED_FLAG_NAMES = $(FLAG_GLYPH_NAMES:%=emoji_%.png)
-RENAMED_FLAG_FILES = $(addprefix $(RENAMED_FLAGS_DIR)/, $(RENAMED_FLAG_NAMES))
-
-EMOJI_NAMES = $(notdir $(wildcard $(EMOJI_SRC_DIR)/emoji_u*.png))
-EMOJI_FILES= $(addprefix $(EMOJI_DIR)/,$(EMOJI_NAMES)))
-
-ALL_NAMES = $(EMOJI_NAMES) $(RENAMED_FLAG_NAMES)
-
-ALL_QUANTIZED_FILES = $(addprefix $(QUANTIZED_DIR)/, $(ALL_NAMES))
-ALL_COMPRESSED_FILES = $(addprefix $(COMPRESSED_DIR)/, $(ALL_NAMES))
+ALL_FILES = $(addprefix $(COMPRESSED_DIR)/,$(EMOJI_SRC_NAMES))
+ALL_COMPRESSED_FILES = $(addprefix $(COMPRESSED_DIR)/,$(EMOJI_NAMES))
 
 # tool checks
 ifeq (,$(shell which $(ZOPFLIPNG)))
@@ -115,15 +58,7 @@ endif
 
 emoji: $(EMOJI_FILES)
 
-flags: $(FLAG_FILES)
-
-resized_flags: $(RESIZED_FLAG_FILES)
-
-renamed_flags: $(RENAMED_FLAG_FILES)
-
-quantized: $(ALL_QUANTIZED_FILES)
-
-compressed: $(ALL_COMPRESSED_FILES)
+compressed: $(ALL_FILES)
 
 check_compress_tool:
 ifdef MISSING_ZOPFLI
@@ -145,53 +80,22 @@ endif
 $(EMOJI_DIR) $(FLAGS_DIR) $(RESIZED_FLAGS_DIR) $(RENAMED_FLAGS_DIR) $(QUANTIZED_DIR) $(COMPRESSED_DIR):
 	mkdir -p "$@"
 
-$(PNGQUANT):
-	$(MAKE) -C $(PNGQUANTDIR)
-
-waveflag: waveflag.c
-	$(CC) $< -o $@ $(CFLAGS) $(LDFLAGS)
-
-
-# imagemagick's -extent operator munges the grayscale images in such a fashion
-# that while it can display them correctly using libpng12, chrome and gimp using
-# both libpng12 and libpng16 display the wrong gray levels.
-#
-# @convert "$<" -gravity center -background none -extent 136x128 "$@"
-#
-# We can get around the conversion to a gray colorspace in the version of
-# imagemagick packaged with ubuntu trusty (6.7.7-10) by using -composite.
-
-$(EMOJI_DIR)/%.png: $(EMOJI_SRC_DIR)/%.png | $(EMOJI_DIR)
-	@convert $(IMOPS) "$<" -composite "PNG32:$@"
-
-$(FLAGS_DIR)/%.png: $(FLAGS_SRC_DIR)/%.png ./waveflag $(PNGQUANT) | $(FLAGS_DIR)
-	@./waveflag $(FLAGS_DIR)/ "$<"
-
-$(RESIZED_FLAGS_DIR)/%.png: $(FLAGS_DIR)/%.png | $(RESIZED_FLAGS_DIR)
-	@convert $(IMOPS) "$<" -composite "PNG32:$@"
-
-flag-symlinks: $(RESIZED_FLAG_FILES) | $(RENAMED_FLAGS_DIR)
-	@$(subst ^, ,                                  \
-	  $(join                                       \
-	    $(FLAGS:%=ln^-fs^../resized_flags/%.png^), \
-	    $(RENAMED_FLAG_FILES:%=%; )                \
-	   )                                           \
-	 )
-
-$(RENAMED_FLAG_FILES): | flag-symlinks
-
-$(QUANTIZED_DIR)/%.png: $(RENAMED_FLAGS_DIR)/%.png $(PNGQUANT) | $(QUANTIZED_DIR)
-	@($(PNGQUANT) $(PNGQUANTFLAGS) -o "$@" "$<"; case "$$?" in "98"|"99") echo "reuse $<"; cp $< $@;; *) exit "$$?";; esac)
-
-$(QUANTIZED_DIR)/%.png: $(EMOJI_DIR)/%.png $(PNGQUANT) | $(QUANTIZED_DIR)
-	@($(PNGQUANT) $(PNGQUANTFLAGS) -o "$@" "$<"; case "$$?" in "98"|"99") echo "reuse $<";cp $< $@;; *) exit "$$?";; esac)
-
-$(COMPRESSED_DIR)/%.png: $(QUANTIZED_DIR)/%.png | check_compress_tool $(COMPRESSED_DIR)
+$(COMPRESSED_DIR)/%.png: $(EMOJI_DIR)/%.png | check_compress_tool $(COMPRESSED_DIR)
 ifdef MISSING_ZOPFLI
 	@$(OPTIPNG) -quiet -o7 -clobber -force -out "$@" "$<"
 else
 	@$(ZOPFLIPNG) -y "$<" "$@" 1> /dev/null 2>&1
 endif
+
+rename: $(ALL_FILES)
+	@$(subst ^, , \
+	  $(join \
+	    $(ALL_FILES:%=mv^%^), \
+	    $(ALL_COMPRESSED_FILES:%=%;^) \
+	  ) \
+	)
+
+$(ALL_COMPRESSED_FILES): rename
 
 
 # Make 3.81 can endless loop here if the target is missing but no
@@ -220,11 +124,10 @@ $(EMOJI).ttf: $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) \
 
 clean:
 	rm -f $(EMOJI).ttf $(EMOJI).tmpl.ttf $(EMOJI).tmpl.ttx
-	rm -f waveflag
 	rm -rf $(BUILD_DIR)
 
-.SECONDARY: $(EMOJI_FILES) $(FLAG_FILES) $(RESIZED_FLAG_FILES) $(RENAMED_FLAG_FILES) \
-  $(ALL_QUANTIZED_FILES) $(ALL_COMPRESSED_FILES)
+.SECONDARY: $(EMOJI_FILES) $(ALL_COMPRESSED_FILES)
 
-.PHONY:	clean flags emoji renamed_flags quantized compressed check_compress_tool
+.PHONY:	clean emoji compressed rename check_compress_tool
+
 

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -1,0 +1,230 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+EMOJI = NotoColorEmoji
+font: $(EMOJI).ttf
+
+CFLAGS = -std=c99 -Wall -Wextra `pkg-config --cflags --libs cairo`
+LDFLAGS = -lm `pkg-config --libs cairo`
+PNGQUANTDIR := third_party/pngquant
+PNGQUANT := $(PNGQUANTDIR)/pngquant
+PNGQUANTFLAGS = --speed 1 --skip-if-larger --quality 85-95 --force
+IMOPS = -size 136x128 canvas:none -compose copy -gravity center
+
+# zopflipng is better (about 5-10%) but much slower.  it will be used if
+# present.  pass ZOPFLIPNG= as an arg to make to use optipng instead.
+
+ZOPFLIPNG = zopflipng
+OPTIPNG = optipng
+
+EMOJI_BUILDER = third_party/color_emoji/emoji_builder.py
+ADD_GLYPHS = add_glyphs.py
+ADD_GLYPHS_FLAGS = -a emoji_aliases.txt
+PUA_ADDER = map_pua_emoji.py
+VS_ADDER = add_vs_cmap.py # from nototools
+
+EMOJI_SRC_DIR := png/128
+FLAGS_SRC_DIR := third_party/region-flags/png
+
+BUILD_DIR := build
+EMOJI_DIR := $(BUILD_DIR)/emoji
+FLAGS_DIR := $(BUILD_DIR)/flags
+RESIZED_FLAGS_DIR := $(BUILD_DIR)/resized_flags
+RENAMED_FLAGS_DIR := $(BUILD_DIR)/renamed_flags
+QUANTIZED_DIR := $(BUILD_DIR)/quantized_pngs
+COMPRESSED_DIR := $(BUILD_DIR)/compressed_pngs
+
+# Unknown flag is PUA fe82b
+
+LIMITED_FLAGS = CN DE ES FR GB IT JP KR RU US
+SELECTED_FLAGS = AC AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ \
+	BA BB BD BE BF BG BH BI BJ BM BN BO BR BS BT BW BY BZ \
+	CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ \
+	DE DJ DK DM DO DZ \
+	EC EE EG ER ES ET EU \
+	FI FJ FM FO FR \
+	GA GB GD GE GG GH GI GL GM GN GQ GR GT GU GW GY \
+	HK HN HR HT HU \
+	IC ID IE IL IM IN IO IQ IR IS IT \
+	JE JM JO JP \
+	KE KG KH KI KM KN KP KR KW KY KZ \
+	LA LB LC LI LK LR LS LT LU LV LY \
+	MA MC MD ME MG MH MK ML MM MN MO MP MR MS MT MU MV MW MX MY MZ \
+	NA NE NF NG NI NL NO NP NR NU NZ \
+	OM \
+	PA PE PF PG PH PK PL PN PR PS PT PW PY \
+	QA \
+	RO RS RU RW \
+	SA SB SC SD SE SG SH SI SK SL SM SN SO SR SS ST SV SX SY SZ \
+	TA TC TD TG TH TJ TK TL TM TN TO TR TT TV TW TZ \
+	UA UG UN US UY UZ \
+	VA VC VE VG VI VN VU \
+	WS \
+	YE \
+	ZA ZM ZW \
+        GB-ENG GB-SCT GB-WLS
+
+ALL_FLAGS = $(basename $(notdir $(wildcard $(FLAGS_SRC_DIR)/*.png)))
+
+FLAGS = $(SELECTED_FLAGS)
+
+FLAG_NAMES = $(FLAGS:%=%.png)
+FLAG_FILES = $(addprefix $(FLAGS_DIR)/, $(FLAG_NAMES))
+RESIZED_FLAG_FILES = $(addprefix $(RESIZED_FLAGS_DIR)/, $(FLAG_NAMES))
+
+FLAG_GLYPH_NAMES = $(shell ./flag_glyph_name.py $(FLAGS))
+RENAMED_FLAG_NAMES = $(FLAG_GLYPH_NAMES:%=emoji_%.png)
+RENAMED_FLAG_FILES = $(addprefix $(RENAMED_FLAGS_DIR)/, $(RENAMED_FLAG_NAMES))
+
+EMOJI_NAMES = $(notdir $(wildcard $(EMOJI_SRC_DIR)/emoji_u*.png))
+EMOJI_FILES= $(addprefix $(EMOJI_DIR)/,$(EMOJI_NAMES)))
+
+ALL_NAMES = $(EMOJI_NAMES) $(RENAMED_FLAG_NAMES)
+
+ALL_QUANTIZED_FILES = $(addprefix $(QUANTIZED_DIR)/, $(ALL_NAMES))
+ALL_COMPRESSED_FILES = $(addprefix $(COMPRESSED_DIR)/, $(ALL_NAMES))
+
+# tool checks
+ifeq (,$(shell which $(ZOPFLIPNG)))
+  ifeq (,$(wildcard $(ZOPFLIPNG)))
+    MISSING_ZOPFLI = fail
+  endif
+endif
+
+ifeq (,$(shell which $(OPTIPNG)))
+  ifeq (,$(wildcard $(OPTIPNG)))
+    MISSING_OPTIPNG = fail
+  endif
+endif
+
+ifeq (, $(shell which $(VS_ADDER)))
+  MISSING_ADDER = fail
+endif
+
+
+emoji: $(EMOJI_FILES)
+
+flags: $(FLAG_FILES)
+
+resized_flags: $(RESIZED_FLAG_FILES)
+
+renamed_flags: $(RENAMED_FLAG_FILES)
+
+quantized: $(ALL_QUANTIZED_FILES)
+
+compressed: $(ALL_COMPRESSED_FILES)
+
+check_compress_tool:
+ifdef MISSING_ZOPFLI
+  ifdef MISSING_OPTIPNG
+	$(error "neither $(ZOPFLIPNG) nor $(OPTIPNG) is available")
+  else
+	@echo "using $(OPTIPNG)"
+  endif
+else
+	@echo "using $(ZOPFLIPNG)"
+endif
+
+check_vs_adder:
+ifdef MISSING_ADDER
+	$(error "$(VS_ADDER) not in path, run setup.py in nototools")
+endif
+
+
+$(EMOJI_DIR) $(FLAGS_DIR) $(RESIZED_FLAGS_DIR) $(RENAMED_FLAGS_DIR) $(QUANTIZED_DIR) $(COMPRESSED_DIR):
+	mkdir -p "$@"
+
+$(PNGQUANT):
+	$(MAKE) -C $(PNGQUANTDIR)
+
+waveflag: waveflag.c
+	$(CC) $< -o $@ $(CFLAGS) $(LDFLAGS)
+
+
+# imagemagick's -extent operator munges the grayscale images in such a fashion
+# that while it can display them correctly using libpng12, chrome and gimp using
+# both libpng12 and libpng16 display the wrong gray levels.
+#
+# @convert "$<" -gravity center -background none -extent 136x128 "$@"
+#
+# We can get around the conversion to a gray colorspace in the version of
+# imagemagick packaged with ubuntu trusty (6.7.7-10) by using -composite.
+
+$(EMOJI_DIR)/%.png: $(EMOJI_SRC_DIR)/%.png | $(EMOJI_DIR)
+	@convert $(IMOPS) "$<" -composite "PNG32:$@"
+
+$(FLAGS_DIR)/%.png: $(FLAGS_SRC_DIR)/%.png ./waveflag $(PNGQUANT) | $(FLAGS_DIR)
+	@./waveflag $(FLAGS_DIR)/ "$<"
+
+$(RESIZED_FLAGS_DIR)/%.png: $(FLAGS_DIR)/%.png | $(RESIZED_FLAGS_DIR)
+	@convert $(IMOPS) "$<" -composite "PNG32:$@"
+
+flag-symlinks: $(RESIZED_FLAG_FILES) | $(RENAMED_FLAGS_DIR)
+	@$(subst ^, ,                                  \
+	  $(join                                       \
+	    $(FLAGS:%=ln^-fs^../resized_flags/%.png^), \
+	    $(RENAMED_FLAG_FILES:%=%; )                \
+	   )                                           \
+	 )
+
+$(RENAMED_FLAG_FILES): | flag-symlinks
+
+$(QUANTIZED_DIR)/%.png: $(RENAMED_FLAGS_DIR)/%.png $(PNGQUANT) | $(QUANTIZED_DIR)
+	@($(PNGQUANT) $(PNGQUANTFLAGS) -o "$@" "$<"; case "$$?" in "98"|"99") echo "reuse $<"; cp $< $@;; *) exit "$$?";; esac)
+
+$(QUANTIZED_DIR)/%.png: $(EMOJI_DIR)/%.png $(PNGQUANT) | $(QUANTIZED_DIR)
+	@($(PNGQUANT) $(PNGQUANTFLAGS) -o "$@" "$<"; case "$$?" in "98"|"99") echo "reuse $<";cp $< $@;; *) exit "$$?";; esac)
+
+$(COMPRESSED_DIR)/%.png: $(QUANTIZED_DIR)/%.png | check_compress_tool $(COMPRESSED_DIR)
+ifdef MISSING_ZOPFLI
+	@$(OPTIPNG) -quiet -o7 -clobber -force -out "$@" "$<"
+else
+	@$(ZOPFLIPNG) -y "$<" "$@" 1> /dev/null 2>&1
+endif
+
+
+# Make 3.81 can endless loop here if the target is missing but no
+# prerequisite is updated and make has been invoked with -j, e.g.:
+# File `font' does not exist.
+#      File `NotoColorEmoji.tmpl.ttx' does not exist.
+# File `font' does not exist.
+#      File `NotoColorEmoji.tmpl.ttx' does not exist.
+# ...
+# Run make without -j if this happens.
+
+%.ttx: %.ttx.tmpl $(ADD_GLYPHS) $(ALL_COMPRESSED_FILES)
+	@python $(ADD_GLYPHS) -f "$<" -o "$@" -d "$(COMPRESSED_DIR)" $(ADD_GLYPHS_FLAGS)
+
+%.ttf: %.ttx
+	@rm -f "$@"
+	ttx "$<"
+
+$(EMOJI).ttf: $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) \
+	$(ALL_COMPRESSED_FILES) | check_vs_adder
+	@python $(EMOJI_BUILDER) -V $< "$@" "$(COMPRESSED_DIR)/emoji_u"
+	@python $(PUA_ADDER) "$@" "$@-with-pua"
+	@$(VS_ADDER) -vs 2640 2642 2695 --dstdir '.' -o "$@-with-pua-varsel" "$@-with-pua"
+	@mv "$@-with-pua-varsel" "$@"
+	@rm "$@-with-pua"
+
+clean:
+	rm -f $(EMOJI).ttf $(EMOJI).tmpl.ttf $(EMOJI).tmpl.ttx
+	rm -f waveflag
+	rm -rf $(BUILD_DIR)
+
+.SECONDARY: $(EMOJI_FILES) $(FLAG_FILES) $(RESIZED_FLAG_FILES) $(RENAMED_FLAG_FILES) \
+  $(ALL_QUANTIZED_FILES) $(ALL_COMPRESSED_FILES)
+
+.PHONY:	clean flags emoji renamed_flags quantized compressed check_compress_tool
+

--- a/linux/README.md
+++ b/linux/README.md
@@ -1,0 +1,63 @@
+![Noto](images/noto.png)
+# Noto Emoji
+Color and Black-and-White Noto emoji fonts, and tools for working with them.
+
+## Building NotoColorEmoji
+
+Building NotoColorEmoji requires a few files from nototools.  Clone a copy from
+https://github.com/googlei18n/nototools and either put it in your PYTHONPATH or
+use 'python setup.py develop' ('install' currently won't fully install all the
+data used by nototools).  You will also need fontTools, get it from
+https://github.com/behdad/fonttools.git.
+
+Then run make.  NotoColorEmoji is the default target.  It's suggested to use -j,
+especially if you are using zopflipng for compression.  Intermediate products
+(compressed image files, for example) will be put into a build subdirectory; the
+font will be at the top level.
+
+## Using NotoColorEmoji
+
+NotoColorEmoji uses the CBDT/CBLC color font format, which is supported by Android
+and Chrome/Chromium OS, but not MacOS.  Windows supports it starting with Windows 10
+Anniversary Update.   No Browser on MacOS supports it, but Edge (on latest Windows)
+does.  Chrome on Linux will support it with some fontconfig tweaking, see
+[issue #36](https://github.com/googlei18n/noto-emoji/issues/36). Currently we do
+not build other color font formats.
+
+## Color emoji assets
+
+The assets provided in the repo are all those used to build the NotoColorEmoji
+font.  Note however that NotoColorEmoji often uses the same assets to represent
+different character sequences-- notably, most gender-neutral characters or
+sequences are represented using assets named after one of the gendered
+sequences.  This means that some sequences appear to be missing.  Definitions of
+the aliasing used appear in the aliases.txt file.
+
+Also note that the images in the font might differ from the original assets.  In
+particular the flag images in the font are PNG images to which transforms have
+been applied to standardize the size and generate the wave and border shadow.  We
+do not have SVG versions that reflect these transforms.
+
+## B/W emoji font
+
+The black-and-white emoji font is not under active development.  Its repertoire of
+emoji is now several years old, and the design does not reflect the current color
+emoji design.  Currently we have no plans to update this font.
+
+## License
+
+Emoji fonts (under the fonts subdirectory) are under the
+[SIL Open Font License, version 1.1](fonts/LICENSE).<br/>
+Tools and most image resources are under the [Apache license, version 2.0](./LICENSE).
+Flag images under third_party/region-flags are in the public domain or
+otherwise exempt from copyright ([more info](third_party/region-flags/LICENSE)).
+
+## Contributing
+
+Please read [CONTRIBUTING](CONTRIBUTING.md) if you are thinking of contributing to this project.
+
+## News
+
+* 2017-09-13: Emoji redesign released.
+* 2015-12-09: Unicode 7 and 8 emoji image data (.png format) added.
+* 2015-09-29: All Noto fonts now licensed under the SIL Open Font License.

--- a/linux/add_aliases.py
+++ b/linux/add_aliases.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+#
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import argparse
+import glob
+import os
+from os import path
+import shutil
+import sys
+
+"""Create aliases in target directory.
+
+The target files should not contain the emoji variation selector
+codepoint in their names."""
+
+DATA_ROOT = path.dirname(path.abspath(__file__))
+
+def str_to_seq(seq_str):
+  res = [int(s, 16) for s in seq_str.split('_')]
+  if 0xfe0f in res:
+    print('0xfe0f in file name: %s' % seq_str)
+    res = [x for x in res if x != 0xfe0f]
+  return tuple(res)
+
+
+def seq_to_str(seq):
+  return '_'.join('%04x' % cp for cp in seq)
+
+
+def read_default_unknown_flag_aliases():
+  unknown_flag_path = path.join(DATA_ROOT, 'unknown_flag_aliases.txt')
+  return read_emoji_aliases(unknown_flag_path)
+
+
+def read_default_emoji_aliases():
+  alias_path = path.join(DATA_ROOT, 'emoji_aliases.txt')
+  return read_emoji_aliases(alias_path)
+
+
+def read_emoji_aliases(filename):
+  result = {}
+
+  with open(filename, 'r') as f:
+    for line in f:
+      ix = line.find('#')
+      if (ix > -1):
+        line = line[:ix]
+      line = line.strip()
+      if not line:
+        continue
+      als, trg = (s.strip() for s in line.split(';'))
+      try:
+        als_seq = tuple([int(x, 16) for x in als.split('_')])
+        trg_seq = tuple([int(x, 16) for x in trg.split('_')])
+      except:
+        print('cannot process alias %s -> %s' % (als, trg))
+        continue
+      result[als_seq] = trg_seq
+  return result
+
+
+def add_aliases(
+    srcdir, dstdir, aliasfile, prefix, ext, replace=False, copy=False,
+    dry_run=False):
+  """Use aliasfile to create aliases of files in srcdir matching prefix/ext in
+  dstdir.  If dstdir is null, use srcdir as dstdir.  If replace is false
+  and a file already exists in dstdir, report and do nothing.  If copy is false
+  create a symlink, else create a copy.  If dry_run is true, report what would
+  be done.  Dstdir will be created if necessary, even if dry_run is true."""
+
+  if not path.isdir(srcdir):
+    print('%s is not a directory' % srcdir, file=sys.stderr)
+    return
+
+  if not dstdir:
+    dstdir = srcdir
+  elif not path.isdir(dstdir):
+    os.makedirs(dstdir)
+
+  prefix_len = len(prefix)
+  suffix_len = len(ext) + 1
+  filenames = [path.basename(f)
+               for f in glob.glob(path.join(srcdir, '%s*.%s' % (prefix, ext)))]
+  seq_to_file = {
+      str_to_seq(name[prefix_len:-suffix_len]) : name
+      for name in filenames}
+
+  aliases = read_emoji_aliases(aliasfile)
+  aliases_to_create = {}
+  aliases_to_replace = []
+  alias_exists = False
+  for als, trg in sorted(aliases.items()):
+    if trg not in seq_to_file:
+      print('target %s for %s does not exist' % (
+          seq_to_str(trg), seq_to_str(als)), file=sys.stderr)
+      continue
+    alias_name = '%s%s.%s' % (prefix, seq_to_str(als), ext)
+    alias_path = path.join(dstdir, alias_name)
+    if path.exists(alias_path):
+      if replace:
+        aliases_to_replace.append(alias_name)
+      else:
+        print('alias %s exists' % seq_to_str(als), file=sys.stderr)
+        alias_exists = True
+        continue
+    target_file = seq_to_file[trg]
+    aliases_to_create[alias_name] = target_file
+
+  if replace:
+    if not dry_run:
+      for k in sorted(aliases_to_replace):
+        os.remove(path.join(dstdir, k))
+    print('replacing %d files' % len(aliases_to_replace))
+  elif alias_exists:
+    print('aborting, aliases exist.', file=sys.stderr)
+    return
+
+  for k, v in sorted(aliases_to_create.items()):
+    if dry_run:
+      msg = 'replace ' if k in aliases_to_replace else ''
+      print('%s%s -> %s' % (msg, k, v))
+    else:
+      try:
+        if copy:
+          shutil.copy2(path.join(srcdir, v), path.join(dstdir, k))
+        else:
+          # fix this to create relative symlinks
+          if srcdir == dstdir:
+            os.symlink(v, path.join(dstdir, k))
+          else:
+            raise Exception('can\'t create cross-directory symlinks yet')
+      except Exception as e:
+        print('failed to create %s -> %s' % (k, v), file=sys.stderr)
+        raise Exception('oops, ' + str(e))
+  print('created %d %s' % (
+      len(aliases_to_create), 'copies' if copy else 'symlinks'))
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '-s', '--srcdir', help='directory containing files to alias',
+      required=True, metavar='dir')
+  parser.add_argument(
+      '-d', '--dstdir', help='directory to write aliases, default srcdir',
+      metavar='dir')
+  parser.add_argument(
+      '-a', '--aliasfile', help='alias file (default emoji_aliases.txt)',
+      metavar='file', default='emoji_aliases.txt')
+  parser.add_argument(
+      '-p', '--prefix', help='file name prefix (default emoji_u)',
+      metavar='pfx', default='emoji_u')
+  parser.add_argument(
+      '-e', '--ext', help='file name extension (default png)',
+      choices=['ai', 'png', 'svg'], default='png')
+  parser.add_argument(
+      '-r', '--replace', help='replace existing files/aliases',
+      action='store_true')
+  parser.add_argument(
+      '-c', '--copy', help='create a copy of the file, not a symlink',
+      action='store_true')
+  parser.add_argument(
+      '-n', '--dry_run', help='print out aliases to create only',
+      action='store_true')
+  args = parser.parse_args()
+
+  add_aliases(
+      args.srcdir, args.dstdir, args.aliasfile, args.prefix, args.ext,
+      args.replace, args.copy, args.dry_run)
+
+
+if __name__ == '__main__':
+  main()

--- a/linux/add_emoji_gsub.py
+++ b/linux/add_emoji_gsub.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+#
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Modify the Noto Color Emoji font to use GSUB rules for flags and keycaps."""
+
+__author__ = "roozbeh@google.com (Roozbeh Pournader)"
+
+
+import sys
+
+from fontTools import agl
+from fontTools import ttLib
+from fontTools.ttLib.tables import otTables
+
+from nototools import font_data
+
+
+def create_script_list(script_tag='DFLT'):
+    """Create a ScriptList for the GSUB table."""
+    def_lang_sys = otTables.DefaultLangSys()
+    def_lang_sys.ReqFeatureIndex = 0xFFFF
+    def_lang_sys.FeatureCount = 1
+    def_lang_sys.FeatureIndex = [0]
+    def_lang_sys.LookupOrder = None
+
+    script_record = otTables.ScriptRecord()
+    script_record.ScriptTag = script_tag
+    script_record.Script = otTables.Script()
+    script_record.Script.DefaultLangSys = def_lang_sys
+    script_record.Script.LangSysCount = 0
+    script_record.Script.LangSysRecord = []
+
+    script_list = otTables.ScriptList()
+    script_list.ScriptCount = 1
+    script_list.ScriptRecord = [script_record]
+
+    return script_list
+
+
+def create_feature_list(feature_tag, lookup_count):
+    """Create a FeatureList for the GSUB table."""
+    feature_record = otTables.FeatureRecord()
+    feature_record.FeatureTag = feature_tag
+    feature_record.Feature = otTables.Feature()
+    feature_record.Feature.LookupCount = lookup_count
+    feature_record.Feature.LookupListIndex = range(lookup_count)
+    feature_record.Feature.FeatureParams = None
+
+    feature_list = otTables.FeatureList()
+    feature_list.FeatureCount = 1
+    feature_list.FeatureRecord = [feature_record]
+
+    return feature_list
+
+
+def create_lookup_list(lookups):
+    """Create a LookupList for the GSUB table."""
+    lookup_list = otTables.LookupList()
+    lookup_list.LookupCount = len(lookups)
+    lookup_list.Lookup = lookups
+
+    return lookup_list
+
+
+def get_glyph_name_or_create(char, font):
+    """Return the glyph name for a character, creating if it doesn't exist."""
+    cmap = font_data.get_cmap(font)
+    if char in cmap:
+        return cmap[char]
+
+    glyph_name = agl.UV2AGL[char]
+    assert glyph_name not in font.glyphOrder
+
+    font['hmtx'].metrics[glyph_name] = [0, 0]
+    cmap[char] = glyph_name
+
+    if 'glyf' in font:
+        from fontTools.ttLib.tables import _g_l_y_f
+        empty_glyph = _g_l_y_f.Glyph()
+        font['glyf'].glyphs[glyph_name] = empty_glyph
+
+    font.glyphOrder.append(glyph_name)
+    return glyph_name
+
+
+def create_lookup(table, font, flag=0):
+    """Create a Lookup based on mapping table."""
+    cmap = font_data.get_cmap(font)
+
+    ligatures = {}
+    for output, (ch1, ch2) in table.iteritems():
+        output = cmap[output]
+        ch1 = get_glyph_name_or_create(ch1, font)
+        ch2 = get_glyph_name_or_create(ch2, font)
+
+        ligature = otTables.Ligature()
+        ligature.CompCount = 2
+        ligature.Component = [ch2]
+        ligature.LigGlyph = output
+
+        try:
+            ligatures[ch1].append(ligature)
+        except KeyError:
+            ligatures[ch1] = [ligature]
+
+    ligature_subst = otTables.LigatureSubst()
+    ligature_subst.ligatures = ligatures
+
+    lookup = otTables.Lookup()
+    lookup.LookupType = 4
+    lookup.LookupFlag = flag
+    lookup.SubTableCount = 1
+    lookup.SubTable = [ligature_subst]
+
+    return lookup
+
+
+def create_simple_gsub(lookups, script='DFLT', feature='ccmp'):
+    """Create a simple GSUB table."""
+    gsub_class = ttLib.getTableClass('GSUB')
+    gsub = gsub_class('GSUB')
+
+    gsub.table = otTables.GSUB()
+    gsub.table.Version = 1.0
+    gsub.table.ScriptList = create_script_list(script)
+    gsub.table.FeatureList = create_feature_list(feature, len(lookups))
+    gsub.table.LookupList = create_lookup_list(lookups)
+    return gsub
+
+
+def reg_indicator(letter):
+    """Return a regional indicator charater from corresponing capital letter.
+    """
+    return 0x1F1E6 + ord(letter) - ord('A')
+
+
+EMOJI_FLAGS = {
+    0xFE4E5: (reg_indicator('J'), reg_indicator('P')),  # Japan
+    0xFE4E6: (reg_indicator('U'), reg_indicator('S')),  # United States
+    0xFE4E7: (reg_indicator('F'), reg_indicator('R')),  # France
+    0xFE4E8: (reg_indicator('D'), reg_indicator('E')),  # Germany
+    0xFE4E9: (reg_indicator('I'), reg_indicator('T')),  # Italy
+    0xFE4EA: (reg_indicator('G'), reg_indicator('B')),  # United Kingdom
+    0xFE4EB: (reg_indicator('E'), reg_indicator('S')),  # Spain
+    0xFE4EC: (reg_indicator('R'), reg_indicator('U')),  # Russia
+    0xFE4ED: (reg_indicator('C'), reg_indicator('N')),  # China
+    0xFE4EE: (reg_indicator('K'), reg_indicator('R')),  # Korea
+}
+
+KEYCAP = 0x20E3
+
+EMOJI_KEYCAPS = {
+    0xFE82C: (ord('#'), KEYCAP),
+    0xFE82E: (ord('1'), KEYCAP),
+    0xFE82F: (ord('2'), KEYCAP),
+    0xFE830: (ord('3'), KEYCAP),
+    0xFE831: (ord('4'), KEYCAP),
+    0xFE832: (ord('5'), KEYCAP),
+    0xFE833: (ord('6'), KEYCAP),
+    0xFE834: (ord('7'), KEYCAP),
+    0xFE835: (ord('8'), KEYCAP),
+    0xFE836: (ord('9'), KEYCAP),
+    0xFE837: (ord('0'), KEYCAP),
+}
+
+def main(argv):
+    """Modify all the fonts given in the command line."""
+    for font_name in argv[1:]:
+        font = ttLib.TTFont(font_name)
+
+        assert 'GSUB' not in font
+        font['GSUB'] = create_simple_gsub([
+            create_lookup(EMOJI_KEYCAPS, font),
+            create_lookup(EMOJI_FLAGS, font)])
+
+        font_data.delete_from_cmap(
+            font, EMOJI_FLAGS.keys() + EMOJI_KEYCAPS.keys())
+
+        font.save(font_name+'-fixed')
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/linux/add_glyphs.py
+++ b/linux/add_glyphs.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python
+
+"""Extend a ttx file with additional data.
+
+Takes a ttx file and one or more directories containing image files named
+after sequences of codepoints, extends the cmap, hmtx, GSUB, and GlyphOrder
+tables in the source ttx file based on these sequences, and writes out a new
+ttx file.
+
+This can also apply aliases from an alias file."""
+
+import argparse
+import collections
+import os
+from os import path
+import re
+import sys
+
+from fontTools import ttx
+from fontTools.ttLib.tables import otTables
+
+import add_emoji_gsub
+import add_aliases
+
+sys.path.append(
+    path.join(os.path.dirname(__file__), 'third_party', 'color_emoji'))
+from png import PNG
+
+
+def get_seq_to_file(image_dir, prefix, suffix):
+  """Return a mapping from codepoint sequences to files in the given directory,
+  for files that match the prefix and suffix.  File names with this prefix and
+  suffix should consist of codepoints in hex separated by underscore.  'fe0f'
+  (the codepoint of the emoji presentation variation selector) is stripped from
+  the sequence.
+  """
+  start = len(prefix)
+  limit = -len(suffix)
+  seq_to_file = {}
+  for name in os.listdir(image_dir):
+    if not (name.startswith(prefix) and name.endswith(suffix)):
+      continue
+    try:
+      cps = [int(s, 16) for s in name[start:limit].split('_')]
+      seq = tuple(cp for cp in cps if cp != 0xfe0f)
+    except:
+      raise Exception('could not parse "%s"' % name)
+    for cp in cps:
+      if not (0 <= cp <= 0x10ffff):
+        raise Exception('bad codepoint(s) in "%s"' % name)
+    if seq in seq_to_file:
+      raise Exception('duplicate sequence for "%s" in %s' % (name, image_dir))
+    seq_to_file[seq] = path.join(image_dir, name)
+  return seq_to_file
+
+
+def collect_seq_to_file(image_dirs, prefix, suffix):
+  """Return a sequence to file mapping by calling get_seq_to_file on a list
+  of directories.  When sequences for files in later directories match those
+  from earlier directories, the later file replaces the earlier one.
+  """
+  seq_to_file = {}
+  for image_dir in image_dirs:
+    seq_to_file.update(get_seq_to_file(image_dir, prefix, suffix))
+  return seq_to_file
+
+
+def remap_values(seq_to_file, map_fn):
+  return {k: map_fn(v) for k, v in seq_to_file.iteritems()}
+
+
+def get_png_file_to_advance_mapper(lineheight):
+  def map_fn(filename):
+    wid, ht = PNG(filename).get_size()
+    return int(round(float(lineheight) * wid / ht))
+  return map_fn
+
+
+def cp_name(cp):
+  """return uniXXXX or uXXXXX(X) as a name for the glyph mapped to this cp."""
+  return '%s%04X' % ('u' if cp > 0xffff else 'uni', cp)
+
+
+def seq_name(seq):
+  """Sequences of length one get the cp_name.  Others start with 'u' followed by
+  two or more 4-to-6-digit hex strings separated by underscore."""
+  if len(seq) == 1:
+    return cp_name(seq[0])
+  return 'u' + '_'.join('%04X' % cp for cp in seq)
+
+
+def collect_cps(seqs):
+  cps = set()
+  for seq in seqs:
+    cps.update(seq)
+  return cps
+
+
+def get_glyphorder_cps_and_truncate(glyphOrder):
+  """This scans glyphOrder for names that correspond to a single codepoint
+  using the 'u(ni)XXXXXX' syntax.  All names that don't match are moved
+  to the front the glyphOrder list in their original order, and the
+  list is truncated.  The ones that do match are returned as a set of
+  codepoints."""
+  glyph_name_re = re.compile(r'^u(?:ni)?([0-9a-fA-F]{4,6})$')
+  cps = set()
+  write_ix = 0
+  for ix, name in enumerate(glyphOrder):
+    m = glyph_name_re.match(name)
+    if m:
+      cps.add(int(m.group(1), 16))
+    else:
+      glyphOrder[write_ix] = name
+      write_ix += 1
+  del glyphOrder[write_ix:]
+  return cps
+
+
+def get_all_seqs(font, seq_to_advance):
+  """Copies the sequences from seq_to_advance and extends it with single-
+  codepoint sequences from the GlyphOrder table as well as those internal
+  to sequences in seq_to_advance.  Reduces the GlyphOrder table. """
+
+  all_seqs = set(seq_to_advance.keys())
+  # using collect_cps includes cps internal to a seq
+  cps = collect_cps(all_seqs)
+  glyphOrder = font.getGlyphOrder()
+  # extract cps in glyphOrder and reduce glyphOrder to only those that remain
+  glyphOrder_cps = get_glyphorder_cps_and_truncate(glyphOrder)
+  cps.update(glyphOrder_cps)
+  # add new single codepoint sequences from glyphOrder and sequences
+  all_seqs.update((cp,) for cp in cps)
+  return all_seqs
+
+
+def get_font_cmap(font):
+  """Return the first cmap in the font, we assume it exists and is a unicode
+  cmap."""
+  return font['cmap'].tables[0].cmap
+
+
+def add_glyph_data(font, seqs, seq_to_advance, vadvance):
+  """Add hmtx and GlyphOrder data for all sequences in seqs, and ensures there's
+  a cmap entry for each single-codepoint sequence.  Seqs not in seq_to_advance
+  will get a zero advance."""
+
+  # We allow the template cmap to omit mappings for single-codepoint glyphs
+  # defined in the template's GlyphOrder table.  Similarly, the hmtx table can
+  # omit advances.  We assume glyphs named 'uniXXXX' or 'uXXXXX(X)' in the
+  # GlyphOrder table correspond to codepoints based on the name; we don't
+  # attempt to handle other types of names and these must occur in the cmap and
+  # hmtx tables in the template.
+  #
+  # seq_to_advance maps sequences (including single codepoints) to advances.
+  # All codepoints in these sequences will be added to the cmap.  Some cps
+  # in these sequences have no corresponding single-codepoint sequence, they
+  # will also get added.
+  #
+  # The added codepoints have no advance information, so will get a zero
+  # advance.
+
+  cmap = get_font_cmap(font)
+  hmtx = font['hmtx'].metrics
+  vmtx = font['vmtx'].metrics
+
+  # We don't expect sequences to be in the glyphOrder, since we removed all the
+  # single-cp sequences from it and don't expect it to already contain names
+  # corresponding to multiple-cp sequencess.  But just in case, we use
+  # reverseGlyphMap to avoid duplicating names accidentally.
+
+  updatedGlyphOrder = False
+  reverseGlyphMap = font.getReverseGlyphMap()
+
+  # Order the glyphs by grouping all the single-codepoint sequences first,
+  # then order by sequence so that related sequences are together.  We group
+  # by single-codepoint sequence first in order to keep these glyphs together--
+  # they're used in the coverage tables for some of the substitutions, and
+  # those tables can be more compact this way.
+  for seq in sorted(seqs, key=lambda s: (0 if len(s) == 1 else 1, s)):
+    name = seq_name(seq)
+    if len(seq) == 1:
+      cmap[seq[0]] = name
+    advance = seq_to_advance.get(seq, 0)
+    hmtx[name] = [advance, 0]
+    vmtx[name] = [vadvance, 0]
+    if name not in reverseGlyphMap:
+      font.glyphOrder.append(name)
+      updatedGlyphOrder=True
+
+  if updatedGlyphOrder:
+    delattr(font, '_reverseGlyphOrderDict')
+
+
+def add_aliases_to_cmap(font, aliases):
+  """Some aliases might map a single codepoint to some other sequence.  These
+  should map directly to the glyph for that sequence in the cmap.  (Others will
+  map via GSUB).
+  """
+  if not aliases:
+    return
+
+  cp_aliases = [seq for seq in aliases if len(seq) == 1]
+  if not cp_aliases:
+    return
+
+  cmap = get_font_cmap(font)
+  for src_seq in cp_aliases:
+    cp = src_seq[0]
+    name = seq_name(aliases[src_seq])
+    cmap[cp] = name
+
+
+def get_rtl_seq(seq):
+  """Return the rtl variant of the sequence, if it has one, else the empty
+  sequence.
+  """
+  # Sequences with ZWJ or TAG_END in them will reflect.  Fitzpatrick modifiers
+  # however do not, so if we reflect we make a pass to swap them back into their
+  # logical order.
+
+  ZWJ = 0x200d
+  TAG_END = 0xe007f
+  def is_fitzpatrick(cp):
+    return 0x1f3fb <= cp <= 0x1f3ff
+
+  if not (ZWJ in seq or TAG_END in seq):
+    return ()
+
+  rev_seq = list(seq)
+  rev_seq.reverse()
+  for i in xrange(1, len(rev_seq)):
+    if is_fitzpatrick(rev_seq[i-1]):
+      tmp = rev_seq[i]
+      rev_seq[i] = rev_seq[i-1]
+      rev_seq[i-1] = tmp
+  return tuple(rev_seq)
+
+
+def get_gsub_ligature_lookup(font):
+  """If the font does not have a GSUB table, create one with a ligature
+  substitution lookup.  If it does, ensure the first lookup is a properly
+  initialized ligature substitution lookup.  Return the lookup."""
+
+  # The template might include more lookups after lookup 0, if it has a
+  # GSUB table.
+  if 'GSUB' not in font:
+    ligature_subst = otTables.LigatureSubst()
+    ligature_subst.ligatures = {}
+
+    lookup = otTables.Lookup()
+    lookup.LookupType = 4
+    lookup.LookupFlag = 0
+    lookup.SubTableCount = 1
+    lookup.SubTable = [ligature_subst]
+
+    font['GSUB'] = add_emoji_gsub.create_simple_gsub([lookup])
+  else:
+    lookup = font['GSUB'].table.LookupList.Lookup[0]
+    assert lookup.LookupFlag == 0
+
+    # importXML doesn't fully init GSUB structures, so help it out
+    st = lookup.SubTable[0]
+    if not hasattr(lookup, 'LookupType'):
+      assert st.LookupType == 4
+      setattr(lookup, 'LookupType', 4)
+
+    if not hasattr(st, 'ligatures'):
+      setattr(st, 'ligatures', {})
+
+  return lookup
+
+
+def add_ligature_sequences(font, seqs, aliases):
+  """Add ligature sequences."""
+
+  seq_to_target_name = {
+      seq: seq_name(seq) for seq in seqs if len(seq) > 1}
+  if aliases:
+    seq_to_target_name.update({
+        seq: seq_name(aliases[seq]) for seq in aliases if len(seq) > 1})
+  if not seq_to_target_name:
+    return
+
+  rtl_seq_to_target_name = {
+      get_rtl_seq(seq): name for seq, name in seq_to_target_name.iteritems()}
+  seq_to_target_name.update(rtl_seq_to_target_name)
+  # sequences that don't have rtl variants get mapped to the empty sequence,
+  # delete it.
+  if () in seq_to_target_name:
+    del seq_to_target_name[()]
+
+  # organize by first codepoint in sequence
+  keyed_ligatures = collections.defaultdict(list)
+  for t in seq_to_target_name.iteritems():
+    first_cp = t[0][0]
+    keyed_ligatures[first_cp].append(t)
+
+  def add_ligature(lookup, cmap, seq, name):
+    # The sequences consist of codepoints, but the entries in the ligature table
+    # are glyph names.  Aliasing can give single codepoints names based on
+    # sequences (e.g. 'guardsman' with 'male guardsman') so we map the
+    # codepoints through the cmap to get the glyph names.
+    glyph_names = [cmap[cp] for cp in seq]
+
+    lig = otTables.Ligature()
+    lig.CompCount = len(seq)
+    lig.Component = glyph_names[1:]
+    lig.LigGlyph = name
+
+    ligatures = lookup.SubTable[0].ligatures
+    first_name = glyph_names[0]
+    try:
+      ligatures[first_name].append(lig)
+    except KeyError:
+      ligatures[first_name] = [lig]
+
+  lookup = get_gsub_ligature_lookup(font)
+  cmap = get_font_cmap(font)
+  for first_cp in sorted(keyed_ligatures):
+    pairs = keyed_ligatures[first_cp]
+
+    # Sort longest first, this ensures longer sequences with common prefixes
+    # are handled before shorter ones.  The secondary sort is a standard
+    # sort on the codepoints in the sequence.
+    pairs.sort(key = lambda pair: (-len(pair[0]), pair[0]))
+    for seq, name in pairs:
+      add_ligature(lookup, cmap, seq, name)
+
+
+def update_font_data(font, seq_to_advance, vadvance, aliases):
+  """Update the font's cmap, hmtx, GSUB, and GlyphOrder tables."""
+  seqs = get_all_seqs(font, seq_to_advance)
+  add_glyph_data(font, seqs, seq_to_advance, vadvance)
+  add_aliases_to_cmap(font, aliases)
+  add_ligature_sequences(font, seqs, aliases)
+
+
+def apply_aliases(seq_dict, aliases):
+  """Aliases is a mapping from sequence to replacement sequence.  We can use
+  an alias if the target is a key in the dictionary.  Furthermore, if the
+  source is a key in the dictionary, we can delete it.  This updates the
+  dictionary and returns the usable aliases."""
+  usable_aliases = {}
+  for k, v in aliases.iteritems():
+    if v in seq_dict:
+      usable_aliases[k] = v
+      if k in seq_dict:
+        del seq_dict[k]
+  return usable_aliases
+
+
+def update_ttx(in_file, out_file, image_dirs, prefix, ext, aliases_file):
+  if ext != '.png':
+    raise Exception('extension "%s" not supported' % ext)
+
+  seq_to_file = collect_seq_to_file(image_dirs, prefix, ext)
+  if not seq_to_file:
+    raise ValueError(
+        'no sequences with prefix "%s" and extension "%s" in %s' % (
+            prefix, ext, ', '.join(image_dirs)))
+
+  aliases = None
+  if aliases_file:
+    aliases = add_aliases.read_emoji_aliases(aliases_file)
+    aliases = apply_aliases(seq_to_file, aliases)
+
+  font = ttx.TTFont()
+  font.importXML(in_file)
+
+  lineheight = font['hhea'].ascent - font['hhea'].descent
+  map_fn = get_png_file_to_advance_mapper(lineheight)
+  seq_to_advance = remap_values(seq_to_file, map_fn)
+
+  vadvance = font['vhea'].advanceHeightMax if 'vhea' in font else lineheight
+
+  update_font_data(font, seq_to_advance, vadvance, aliases)
+
+  font.saveXML(out_file)
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '-f', '--in_file', help='ttx input file', metavar='file', required=True)
+  parser.add_argument(
+      '-o', '--out_file', help='ttx output file', metavar='file', required=True)
+  parser.add_argument(
+      '-d', '--image_dirs', help='directories containing image files',
+      nargs='+', metavar='dir', required=True)
+  parser.add_argument(
+      '-p', '--prefix', help='file prefix (default "emoji_u")',
+      metavar='pfx', default='emoji_u')
+  parser.add_argument(
+      '-e', '--ext', help='file extension (default ".png", currently only '
+      '".png" is supported',  metavar='ext', default='.png')
+  parser.add_argument(
+      '-a', '--aliases', help='process alias table', const='emoji_aliases.txt',
+      nargs='?', metavar='file')
+  args = parser.parse_args()
+
+  update_ttx(
+      args.in_file, args.out_file, args.image_dirs, args.prefix, args.ext,
+      args.aliases)
+
+
+if __name__ == '__main__':
+  main()

--- a/linux/add_svg_glyphs.py
+++ b/linux/add_svg_glyphs.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python
+# Copyright 2015 Google, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Google Author(s): Doug Felt
+
+"""Tool to update GSUB, hmtx, cmap, glyf tables with svg image glyphs."""
+from __future__ import print_function
+
+import argparse
+import glob
+import logging
+import os
+import re
+import sys
+
+from fontTools.ttLib.tables import otTables
+from fontTools.ttLib.tables import _g_l_y_f
+from fontTools.ttLib.tables import S_V_G_ as SVG
+from fontTools import ttx
+
+from nototools import tool_utils
+
+import add_emoji_gsub
+import svg_builder
+
+
+class FontBuilder(object):
+  """A utility for mutating a ttx font.  This maintains glyph_order, cmap, and
+  hmtx tables, and optionally GSUB, glyf, and SVN tables as well."""
+
+  def __init__(self, font):
+    self.font = font;
+    self.glyph_order = font.getGlyphOrder()
+    self.cmap = font['cmap'].tables[0].cmap
+    self.hmtx = font['hmtx'].metrics
+
+  def init_gsub(self):
+    """Call this if you are going to add ligatures to the font.  Creates a GSUB
+    table if there isn't one already."""
+
+    if hasattr(self, 'ligatures'):
+      return
+    font = self.font
+    if 'GSUB' not in font:
+      ligature_subst = otTables.LigatureSubst()
+      ligature_subst.ligatures = {}
+
+      lookup = otTables.Lookup()
+      lookup.LookupType = 4
+      lookup.LookupFlag = 0
+      lookup.SubTableCount = 1
+      lookup.SubTable = [ligature_subst]
+
+      font['GSUB'] = add_emoji_gsub.create_simple_gsub([lookup])
+    else:
+      lookup = font['GSUB'].table.LookupList.Lookup[0]
+      assert lookup.LookupType == 4
+      assert lookup.LookupFlag == 0
+    self.ligatures = lookup.SubTable[0].ligatures
+
+  def init_glyf(self):
+    """Call this if you need to create empty glyf entries in the font when you
+    add a new glyph."""
+
+    if hasattr(self, 'glyphs'):
+      return
+    font = self.font
+    if 'glyf' not in font:
+      glyf_table = _g_l_y_f.table__g_l_y_f()
+      glyf_table.glyphs = {}
+      glyf_table.glyphOrder = self.glyph_order
+      font['glyf'] = glyf_table
+    self.glyphs = font['glyf'].glyphs
+
+  def init_svg(self):
+    """Call this if you expect to add SVG images in the font. This calls
+    init_glyf since SVG support currently requires fallback glyf records for
+    each SVG image."""
+
+    if hasattr(self, 'svgs'):
+      return
+
+    # svg requires glyf
+    self.init_glyf()
+
+    font = self.font
+    if 'SVG ' not in font:
+      svg_table = SVG.table_S_V_G_()
+      svg_table.docList = []
+      svg_table.colorPalettes = None
+      font['SVG '] = svg_table
+    self.svgs = font['SVG '].docList
+
+  def glyph_name(self, string):
+    return "_".join(["u%04X" % ord(char) for char in string])
+
+  def glyph_name_to_index(self, name):
+    return self.glyph_order.index(name) if name in self.glyph_order else -1;
+
+  def glyph_index_to_name(self, glyph_index):
+    if glyph_index < len(self.glyph_order):
+      return self.glyph_order[glyph_index]
+    return ''
+
+  def have_glyph(self, name):
+    return self.name_to_glyph_index >= 0
+
+  def _add_ligature(self, glyphstr):
+    lig = otTables.Ligature()
+    lig.CompCount = len(glyphstr)
+    lig.Component = [self.glyph_name(ch) for ch in glyphstr[1:]]
+    lig.LigGlyph = self.glyph_name(glyphstr)
+
+    first = self.glyph_name(glyphstr[0])
+    try:
+      self.ligatures[first].append(lig)
+    except KeyError:
+      self.ligatures[first] = [lig]
+
+  def _add_empty_glyph(self, glyphstr, name):
+    """Create an empty glyph. If glyphstr is not a ligature, add a cmap entry
+    for it."""
+    if len(glyphstr) == 1:
+      self.cmap[ord(glyphstr)] = name
+    self.hmtx[name] = [0, 0]
+    self.glyph_order.append(name)
+    if hasattr(self, 'glyphs'):
+      self.glyphs[name] = _g_l_y_f.Glyph()
+
+  def add_components_and_ligature(self, glyphstr):
+    """Convert glyphstr to a name and check if it already exists. If not, check
+    if it is a ligature (longer than one codepoint), and if it is, generate
+    empty glyphs with cmap entries for any missing ligature components and add a
+    ligature record.  Then generate an empty glyph for the name.  Return a tuple
+    with the name, index, and a bool indicating whether the glyph already
+    existed."""
+
+    name = self.glyph_name(glyphstr)
+    index = self.glyph_name_to_index(name)
+    exists = index >= 0
+    if not exists:
+      if len(glyphstr) > 1:
+        for char in glyphstr:
+          if ord(char) not in self.cmap:
+            char_name = self.glyph_name(char)
+            self._add_empty_glyph(char, char_name)
+        self._add_ligature(glyphstr)
+      index = len(self.glyph_order)
+      self._add_empty_glyph(glyphstr, name)
+    return name, index, exists
+
+  def add_svg(self, doc, hmetrics, name, index):
+    """Add an svg table entry. If hmetrics is not None, update the hmtx table.
+    This expects the glyph has already been added."""
+    # sanity check to make sure name and index correspond.
+    assert name == self.glyph_index_to_name(index)
+    if hmetrics:
+      self.hmtx[name] = hmetrics
+    svg_record = (doc, index, index) # startGlyphId, endGlyphId are the same
+    self.svgs.append(svg_record)
+
+
+def collect_glyphstr_file_pairs(prefix, ext, include=None, exclude=None, verbosity=1):
+  """Scan files with the given prefix and extension, and return a list of
+  (glyphstr, filename) where glyphstr is the character or ligature, and filename
+  is the image file associated with it.  The glyphstr is formed by decoding the
+  filename (exclusive of the prefix) as a sequence of hex codepoints separated
+  by underscore. Include, if defined, is a regex string to include only matched
+  filenames. Exclude, if defined, is a regex string to exclude matched
+  filenames, and is applied after include."""
+
+  image_files = {}
+  glob_pat = "%s*.%s" % (prefix, ext)
+  leading = len(prefix)
+  trailing = len(ext) + 1 # include dot
+  logging.info("Looking for images matching '%s'.", glob_pat)
+  ex_count = 0
+  ex = re.compile(exclude) if exclude else None
+  inc = re.compile(include) if include else None
+  if inc:
+    logging.info("Including images matching '%s'.", include)
+  if ex:
+    logging.info("Excluding images matching '%s'.", exclude)
+
+  for image_file in glob.glob(glob_pat):
+    if inc and not inc.search(image_file):
+      continue
+
+    if ex and ex.search(image_file):
+      if verbosity > 1:
+        print("Exclude %s" % image_file)
+      ex_count += 1
+      continue
+
+    codes = image_file[leading:-trailing]
+    if "_" in codes:
+      pieces = codes.split ("_")
+      u = "".join ([unichr(int(code, 16)) for code in pieces])
+    else:
+      u = unichr(int(codes, 16))
+    image_files[u] = image_file
+
+  if ex_count:
+    logging.info("Excluded %d files.", ex_count)
+  if not image_files:
+    raise Exception ("No image files matching '%s'.", glob_pat)
+  logging.info("Matched %s files.", len(image_files))
+  return image_files.items()
+
+
+def sort_glyphstr_tuples(glyphstr_tuples):
+  """The list contains tuples whose first element is a string representing a
+  character or ligature.  It is sorted with shorter glyphstrs first, then
+  alphabetically. This ensures that ligature components are added to the font
+  before any ligatures that contain them."""
+  glyphstr_tuples.sort(key=lambda t: (len(t[0]), t[0]))
+
+
+def add_image_glyphs(in_file, out_file, pairs):
+  """Add images from pairs (glyphstr, filename) to .ttx file in_file and write
+  to .ttx file out_file."""
+
+  font = ttx.TTFont()
+  font.importXML(in_file)
+
+  sort_glyphstr_tuples(pairs)
+
+  font_builder = FontBuilder(font)
+  # we've already sorted by length, so the longest glyphstrs are at the end. To
+  # see if we have ligatures, we just need to check the last one.
+  if len(pairs[-1][0]) > 1:
+    font_builder.init_gsub()
+
+  img_builder = svg_builder.SvgBuilder(font_builder)
+  for glyphstr, filename in pairs:
+    logging.debug("Adding glyph for U+%s", ",".join(
+          ["%04X" % ord(char) for char in glyphstr]))
+    img_builder.add_from_filename(glyphstr, filename)
+
+  font.saveXML(out_file)
+  logging.info("Added %s images to %s", len(pairs), out_file)
+
+
+def main(argv):
+  usage = """This will search for files that have image_prefix followed by one
+  or more hex numbers (separated by underscore if more than one), and end in
+  ".svg". For example, if image_prefix is "icons/u", then files with names like
+  "icons/u1F4A9.svg" or "icons/u1F1EF_1F1F5.svg" will be loaded.  The script
+  then adds cmap, htmx, and potentially GSUB entries for the Unicode characters
+  found.  The advance width will be chosen based on image aspect ratio.  If
+  Unicode values outside the BMP are desired, the existing cmap table should be
+  of the appropriate (format 12) type.  Only the first cmap table and the first
+  GSUB lookup (if existing) are modified."""
+
+  parser = argparse.ArgumentParser(
+      description='Update cmap, glyf, GSUB, and hmtx tables from image glyphs.',
+      epilog=usage)
+  parser.add_argument(
+      'in_file', help='Input ttx file name.', metavar='fname')
+  parser.add_argument(
+      'out_file', help='Output ttx file name.', metavar='fname')
+  parser.add_argument(
+      'image_prefix', help='Location and prefix of image files.',
+      metavar='path')
+  parser.add_argument(
+      '-i', '--include', help='include files whoses name matches this regex',
+      metavar='regex')
+  parser.add_argument(
+      '-e', '--exclude', help='exclude files whose name matches this regex',
+      metavar='regex')
+  parser.add_argument(
+      '-l', '--loglevel', help='log level name', default='warning')
+  args = parser.parse_args(argv)
+
+  tool_utils.setup_logging(args.loglevel)
+
+  pairs = collect_glyphstr_file_pairs(
+      args.image_prefix, 'svg', include=args.include, exclude=args.exclude)
+  add_image_glyphs(args.in_file, args.out_file, pairs)
+
+
+if __name__ == '__main__':
+  main(sys.argv[1:])

--- a/linux/check_emoji_sequences.py
+++ b/linux/check_emoji_sequences.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compare emoji image file namings against unicode property data."""
+from __future__ import print_function
+
+import argparse
+import collections
+import glob
+import os
+from os import path
+import re
+import sys
+
+from nototools import unicode_data
+
+DATA_ROOT = path.dirname(path.abspath(__file__))
+
+ZWJ = 0x200d
+EMOJI_VS = 0xfe0f
+
+def _is_regional_indicator(cp):
+  return 0x1f1e6 <= cp <= 0x1f1ff
+
+
+def _is_skintone_modifier(cp):
+  return 0x1f3fb <= cp <= 0x1f3ff
+
+
+def _seq_string(seq):
+  return '_'.join('%04x' % cp for cp in seq)
+
+def strip_vs(seq):
+  return tuple(cp for cp in seq if cp != EMOJI_VS)
+
+_namedata = None
+
+def seq_name(seq):
+  global _namedata
+
+  if not _namedata:
+    def strip_vs_map(seq_map):
+      return {
+          strip_vs(k): v
+          for k, v in seq_map.iteritems()}
+    _namedata = [
+        strip_vs_map(unicode_data.get_emoji_combining_sequences()),
+        strip_vs_map(unicode_data.get_emoji_flag_sequences()),
+        strip_vs_map(unicode_data.get_emoji_modifier_sequences()),
+        strip_vs_map(unicode_data.get_emoji_zwj_sequences()),
+        ]
+
+  if len(seq) == 1:
+    return unicode_data.name(seq[0], None)
+
+  for data in _namedata:
+    if seq in data:
+      return data[seq]
+  if EMOJI_VS in seq:
+    non_vs_seq = strip_vs(seq)
+    for data in _namedata:
+      if non_vs_seq in data:
+        return data[non_vs_seq]
+
+  return None
+
+
+def _check_valid_emoji(sorted_seq_to_filepath):
+  """Ensure all emoji are either valid emoji or specific chars."""
+
+  valid_cps = set(unicode_data.get_emoji() | unicode_data.proposed_emoji_cps())
+  valid_cps.add(0x200d)  # ZWJ
+  valid_cps.add(0x20e3)  # combining enclosing keycap
+  valid_cps.add(0xfe0f)  # variation selector (emoji presentation)
+  valid_cps.add(0xfe82b)  # PUA value for unknown flag
+
+  not_emoji = {}
+  for seq, fp in sorted_seq_to_filepath.iteritems():
+    for cp in seq:
+      if cp not in valid_cps:
+        if cp not in not_emoji:
+          not_emoji[cp] = []
+        not_emoji[cp].append(fp)
+
+  if len(not_emoji):
+    print('%d non-emoji found:' % len(not_emoji), file=sys.stderr)
+    for cp in sorted(not_emoji):
+      print('%04x (in %s)' % (cp, ', '.join(not_emoji[cp])), file=sys.stderr)
+
+
+def _check_zwj(sorted_seq_to_filepath):
+  """Ensure zwj is only between two appropriate emoji."""
+  ZWJ = 0x200D
+  EMOJI_PRESENTATION_VS = 0xFE0F
+
+  for seq, fp in sorted_seq_to_filepath.iteritems():
+    if ZWJ not in seq:
+      continue
+    if seq[0] == 0x200d:
+      print('zwj at head of sequence in %s' % fp, file=sys.stderr)
+    if len(seq) == 1:
+      continue
+    if seq[-1] == 0x200d:
+      print('zwj at end of sequence in %s' % fp, file=sys.stderr)
+    for i, cp in enumerate(seq):
+      if cp == ZWJ:
+        if i > 0:
+          pcp = seq[i-1]
+          if pcp != EMOJI_PRESENTATION_VS and not unicode_data.is_emoji(pcp):
+            print('non-emoji %04x preceeds ZWJ in %s' % (pcp, fp), file=sys.stderr)
+        if i < len(seq) - 1:
+          fcp = seq[i+1]
+          if not unicode_data.is_emoji(fcp):
+            print('non-emoji %04x follows ZWJ in %s' % (fcp, fp), file=sys.stderr)
+
+
+def _check_flags(sorted_seq_to_filepath):
+  """Ensure regional indicators are only in sequences of one or two, and
+  never mixed."""
+  for seq, fp in sorted_seq_to_filepath.iteritems():
+    have_reg = None
+    for cp in seq:
+      is_reg = _is_regional_indicator(cp)
+      if have_reg == None:
+        have_reg = is_reg
+      elif have_reg != is_reg:
+        print('mix of regional and non-regional in %s' % fp, file=sys.stderr)
+    if have_reg and len(seq) > 2:
+      # We provide dummy glyphs for regional indicators, so there are sequences
+      # with single regional indicator symbols.
+      print('regional indicator sequence length != 2 in %s' % fp, file=sys.stderr)
+
+
+def _check_skintone(sorted_seq_to_filepath):
+  """Ensure skin tone modifiers are not applied to emoji that are not defined
+  to take them.  May appear standalone, though.  Also check that emoji that take
+  skin tone modifiers have a complete set."""
+  base_to_modifiers = collections.defaultdict(set)
+  for seq, fp in sorted_seq_to_filepath.iteritems():
+    for i, cp in enumerate(seq):
+      if _is_skintone_modifier(cp):
+        if i == 0:
+          if len(seq) > 1:
+            print('skin color selector first in sequence %s' % fp, file=sys.stderr)
+          # standalone are ok
+          continue
+        pcp = seq[i-1]
+        if not unicode_data.is_emoji_modifier_base(pcp):
+          print((
+              'emoji skintone modifier applied to non-base at %d: %s' % (i, fp)), file=sys.stderr)
+      elif unicode_data.is_emoji_modifier_base(cp):
+        if i < len(seq) - 1 and _is_skintone_modifier(seq[i+1]):
+          base_to_modifiers[cp].add(seq[i+1])
+        elif cp not in base_to_modifiers:
+          base_to_modifiers[cp] = set()
+  for cp, modifiers in sorted(base_to_modifiers.iteritems()):
+    if len(modifiers) != 5:
+      print('emoji base %04x has %d modifiers defined (%s) in %s' % (
+          cp, len(modifiers),
+          ', '.join('%04x' % cp for cp in sorted(modifiers)), fp), file=sys.stderr)
+
+
+def _check_zwj_sequences(seq_to_filepath):
+  """Verify that zwj sequences are valid."""
+  zwj_sequence_to_name = unicode_data.get_emoji_zwj_sequences()
+  # strip emoji variant selectors and add extra mappings
+  zwj_sequence_without_vs_to_name_canonical = {}
+  for seq, seq_name in zwj_sequence_to_name.iteritems():
+    if EMOJI_VS in seq:
+      stripped_seq = strip_vs(seq)
+      zwj_sequence_without_vs_to_name_canonical[stripped_seq] = (seq_name, seq)
+
+  zwj_seq_to_filepath = {
+      seq: fp for seq, fp in seq_to_filepath.iteritems()
+      if ZWJ in seq}
+
+  for seq, fp in zwj_seq_to_filepath.iteritems():
+    if seq not in zwj_sequence_to_name:
+      if seq not in zwj_sequence_without_vs_to_name_canonical:
+        print('zwj sequence not defined: %s' % fp, file=sys.stderr)
+      else:
+        _, can = zwj_sequence_without_vs_to_name_canonical[seq]
+        # print >> sys.stderr, 'canonical sequence %s contains vs: %s' % (
+        #     _seq_string(can), fp)
+
+def read_emoji_aliases():
+  result = {}
+
+  with open(path.join(DATA_ROOT, 'emoji_aliases.txt'), 'r') as f:
+    for line in f:
+      ix = line.find('#')
+      if (ix > -1):
+        line = line[:ix]
+      line = line.strip()
+      if not line:
+        continue
+      als, trg = (s.strip() for s in line.split(';'))
+      als_seq = tuple([int(x, 16) for x in als.split('_')])
+      try:
+        trg_seq = tuple([int(x, 16) for x in trg.split('_')])
+      except:
+        print('cannot process alias %s -> %s' % (als, trg))
+        continue
+      result[als_seq] = trg_seq
+  return result
+
+
+def _check_coverage(seq_to_filepath):
+  age = 9.0
+
+  non_vs_to_canonical = {}
+  for k in seq_to_filepath:
+    if EMOJI_VS in k:
+      non_vs = strip_vs(k)
+      non_vs_to_canonical[non_vs] = k
+
+  aliases = read_emoji_aliases()
+  for k, v in sorted(aliases.items()):
+    if v not in seq_to_filepath and v not in non_vs_to_canonical:
+      print('alias %s missing target %s' % (_seq_string(k), _seq_string(v)))
+      continue
+    if k in seq_to_filepath or k in non_vs_to_canonical:
+      print('alias %s already exists as %s (%s)' % (
+          _seq_string(k), _seq_string(v), seq_name(v)))
+      continue
+    filename = seq_to_filepath.get(v) or seq_to_filepath[non_vs_to_canonical[v]]
+    seq_to_filepath[k] = 'alias:' + filename
+
+  # check single emoji, this includes most of the special chars
+  emoji = sorted(unicode_data.get_emoji(age=age))
+  for cp in emoji:
+    if tuple([cp]) not in seq_to_filepath:
+      print('missing single %04x (%s)' % (cp, unicode_data.name(cp, '<no name>')))
+
+  # special characters
+  # all but combining enclosing keycap are currently marked as emoji
+  for cp in [ord('*'), ord('#'), ord(u'\u20e3')] + range(0x30, 0x3a):
+    if cp not in emoji and tuple([cp]) not in seq_to_filepath:
+      print('missing special %04x (%s)' % (cp, unicode_data.name(cp)))
+
+  # combining sequences
+  comb_seq_to_name = sorted(
+      unicode_data.get_emoji_combining_sequences(age=age).iteritems())
+  for seq, name in comb_seq_to_name:
+    if seq not in seq_to_filepath:
+      # strip vs and try again
+      non_vs_seq = strip_vs(seq)
+      if non_vs_seq not in seq_to_filepath:
+        print('missing combining sequence %s (%s)' % (_seq_string(seq), name))
+
+  # flag sequences
+  flag_seq_to_name = sorted(
+      unicode_data.get_emoji_flag_sequences(age=age).iteritems())
+  for seq, name in flag_seq_to_name:
+    if seq not in seq_to_filepath:
+      print('missing flag sequence %s (%s)' % (_seq_string(seq), name))
+
+  # skin tone modifier sequences
+  mod_seq_to_name = sorted(
+      unicode_data.get_emoji_modifier_sequences(age=age).iteritems())
+  for seq, name in mod_seq_to_name:
+    if seq not in seq_to_filepath:
+      print('missing modifier sequence %s (%s)' % (
+          _seq_string(seq), name))
+
+  # zwj sequences
+  # some of ours include the emoji presentation variation selector and some
+  # don't, and the same is true for the canonical sequences.  normalize all
+  # of them to omit it to test coverage, but report the canonical sequence.
+  zwj_seq_without_vs = set()
+  for seq in seq_to_filepath:
+    if ZWJ not in seq:
+      continue
+    if EMOJI_VS in seq:
+      seq = tuple(cp for cp in seq if cp != EMOJI_VS)
+    zwj_seq_without_vs.add(seq)
+
+  for seq, name in sorted(
+      unicode_data.get_emoji_zwj_sequences(age=age).iteritems()):
+    if EMOJI_VS in seq:
+      test_seq = tuple(s for s in seq if s != EMOJI_VS)
+    else:
+      test_seq = seq
+    if test_seq not in zwj_seq_without_vs:
+      print('missing (canonical) zwj sequence %s (%s)' % (
+          _seq_string(seq), name))
+
+  # check for 'unknown flag'
+  # this is either emoji_ufe82b or 'unknown_flag', we filter out things that
+  # don't start with our prefix so 'unknown_flag' would be excluded by default.
+  if tuple([0xfe82b]) not in seq_to_filepath:
+    print('missing unknown flag PUA fe82b')
+
+
+def check_sequence_to_filepath(seq_to_filepath):
+  sorted_seq_to_filepath = collections.OrderedDict(
+      sorted(seq_to_filepath.items()))
+  _check_valid_emoji(sorted_seq_to_filepath)
+  _check_zwj(sorted_seq_to_filepath)
+  _check_flags(sorted_seq_to_filepath)
+  _check_skintone(sorted_seq_to_filepath)
+  _check_zwj_sequences(sorted_seq_to_filepath)
+  _check_coverage(sorted_seq_to_filepath)
+
+def create_sequence_to_filepath(name_to_dirpath, prefix, suffix):
+  """Check names, and convert name to sequences for names that are ok,
+  returning a sequence to file path mapping.  Reports bad segments
+  of a name to stderr."""
+  segment_re = re.compile(r'^[0-9a-f]{4,6}$')
+  result = {}
+  for name, dirname in name_to_dirpath.iteritems():
+    if not name.startswith(prefix):
+      print('expected prefix "%s" for "%s"' % (prefix, name))
+      continue
+
+    segments = name[len(prefix): -len(suffix)].split('_')
+    segfail = False
+    seq = []
+    for s in segments:
+      if not segment_re.match(s):
+        print('bad codepoint name "%s" in %s/%s' % (s, dirname, name))
+        segfail = True
+        continue
+      n = int(s, 16)
+      if n > 0x10ffff:
+        print('codepoint "%s" out of range in %s/%s' % (s, dirname, name))
+        segfail = True
+        continue
+      seq.append(n)
+    if not segfail:
+      result[tuple(seq)] = path.join(dirname, name)
+  return result
+
+
+def collect_name_to_dirpath(directory, prefix, suffix):
+  """Return a mapping from filename to path rooted at directory, ignoring files
+  that don't match suffix.  Report when a filename appears in more than one
+  subdir; the first path found is kept."""
+  result = {}
+  for dirname, _, files in os.walk(directory):
+    if directory != '.':
+      dirname = path.join(directory, dirname)
+    for f in files:
+      if not f.endswith(suffix):
+        continue
+      if f in result:
+        print('duplicate file "%s" in %s and %s ' % (
+            f, dirname, result[f]), file=sys.stderr)
+        continue
+      result[f] = dirname
+  return result
+
+
+def collect_name_to_dirpath_with_override(dirs, prefix, suffix):
+  """Return a mapping from filename to a directory path rooted at a directory
+  in dirs, using collect_name_to_filepath.  The last directory is retained. This
+  does not report an error if a file appears under more than one root directory,
+  so lets later root directories override earlier ones."""
+  result = {}
+  for d in dirs:
+    result.update(collect_name_to_dirpath(d, prefix, suffix))
+  return result
+
+
+def run_check(dirs, prefix, suffix):
+  print('Checking files with prefix "%s" and suffix "%s" in:\n  %s' % (
+      prefix, suffix, '\n  '.join(dirs)))
+  name_to_dirpath = collect_name_to_dirpath_with_override(
+      dirs, prefix=prefix, suffix=suffix)
+  print('checking %d names' % len(name_to_dirpath))
+  seq_to_filepath = create_sequence_to_filepath(name_to_dirpath, prefix, suffix)
+  print('checking %d sequences' % len(seq_to_filepath))
+  check_sequence_to_filepath(seq_to_filepath)
+  print('done.')
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '-d', '--dirs', help='directories containing emoji images',
+      metavar='dir', nargs='+', required=True)
+  parser.add_argument(
+      '-p', '--prefix', help='prefix to match, default "emoji_u"',
+      metavar='pfx', default='emoji_u')
+  parser.add_argument(
+      '-s', '--suffix', help='suffix to match, default ".png"', metavar='sfx',
+      default='.png')
+  args = parser.parse_args()
+  run_check(args.dirs, args.prefix, args.suffix)
+
+
+if __name__ == '__main__':
+  main()

--- a/linux/collect_emoji_svg.py
+++ b/linux/collect_emoji_svg.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+# Copyright 2015 Google, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Google Author(s): Doug Felt
+
+"""Tool to collect emoji svg glyphs into one directory for processing
+by add_svg_glyphs.  There are two sources, noto/color_emoji/svg and
+noto/third_party/region-flags/svg.  The add_svg_glyphs file expects
+the file names to contain the character string that represents it
+represented as a sequence of hex-encoded codepoints separated by
+underscore.  The files in noto/color_emoji/svg do this, and have the
+prefix 'emoji_u', but the files in region-flags/svg just have the
+two-letter code.
+
+We create a directory and copy the files into it with the required
+naming convention. First we do this for region-flags/svg, converting
+the names, and then we do this for color_emoji/svg, so any duplicates
+will be overwritten by what we assume are the preferred svg.  We use
+copies instead of symlinks so we can continue to optimize or modify
+the files without messing with the originals."""
+
+import argparse
+import glob
+import logging
+import os
+import os.path
+import re
+import shutil
+import sys
+
+from nototools import tool_utils
+
+def _is_svg(f):
+  return f.endswith('.svg')
+
+
+def _is_svg_and_startswith_emoji(f):
+  return f.endswith('.svg') and f.startswith('emoji_u')
+
+
+def _flag_rename(f):
+  """Converts a file name from two-letter upper-case ASCII to our expected
+  'emoji_uXXXXX_XXXXX form, mapping each character to the corresponding
+  regional indicator symbol."""
+
+  cp_strs = []
+  name, ext = os.path.splitext(f)
+  if len(name) != 2:
+    raise ValueError('illegal flag name "%s"' % f)
+  for cp in name:
+    if not ('A' <= cp <= 'Z'):
+      raise ValueError('illegal flag name "%s"' % f)
+    ncp = 0x1f1e6 - 0x41 + ord(cp)
+    cp_strs.append("%04x" % ncp)
+  return 'emoji_u%s%s' % ('_'.join(cp_strs), ext)
+
+
+def copy_with_rename(src_dir, dst_dir, accept_pred=None, rename=None):
+  """Copy files from src_dir to dst_dir that match accept_pred (all if None) and
+  rename using rename (if not None), replacing existing files.  accept_pred
+  takes the filename and returns True if the file should be copied, rename takes
+  the filename and returns a new file name."""
+
+  count = 0
+  replace_count = 0
+  for src_filename in os.listdir(src_dir):
+    if accept_pred and not accept_pred(src_filename):
+      continue
+    dst_filename = rename(src_filename) if rename else src_filename
+    src = os.path.join(src_dir, src_filename)
+    dst = os.path.join(dst_dir, dst_filename)
+    if os.path.exists(dst):
+      logging.debug('Replacing existing file %s', dst)
+      os.unlink(dst)
+      replace_count += 1
+    shutil.copy2(src, dst)
+    logging.debug('cp -p %s %s', src, dst)
+    count += 1
+  if logging.getLogger().getEffectiveLevel() <= logging.INFO:
+    src_short = tool_utils.short_path(src_dir)
+    dst_short = tool_utils.short_path(dst_dir)
+    logging.info('Copied %d files (replacing %d) from %s to %s',
+        count, replace_count, src_short, dst_short)
+
+
+def build_svg_dir(dst_dir, clean=False, emoji_dir='', flags_dir=''):
+  """Copies/renames files from emoji_dir and then flags_dir, giving them the
+  standard format and prefix ('emoji_u' followed by codepoints expressed in hex
+  separated by underscore).  If clean, removes the target dir before proceding.
+  If either emoji_dir or flags_dir are empty, skips them."""
+
+  dst_dir = tool_utils.ensure_dir_exists(dst_dir, clean=clean)
+
+  if not emoji_dir and not flags_dir:
+    logging.warning('Nothing to do.')
+    return
+
+  if emoji_dir:
+    copy_with_rename(
+        emoji_dir, dst_dir, accept_pred=_is_svg_and_startswith_emoji)
+
+  if flags_dir:
+     copy_with_rename(
+        flags_dir, dst_dir, accept_pred=_is_svg, rename=_flag_rename)
+
+
+def main(argv):
+  DEFAULT_EMOJI_DIR = '[emoji]/svg'
+  DEFAULT_FLAGS_DIR = '[emoji]/third_party/region-flags/svg'
+
+  parser = argparse.ArgumentParser(
+      description='Collect svg files into target directory with prefix.')
+  parser.add_argument(
+      'dst_dir', help='Directory to hold copied files.', metavar='dir')
+  parser.add_argument(
+      '--clean', '-c', help='Replace target directory', action='store_true')
+  parser.add_argument(
+      '--flags_dir', '-f', metavar='dir', help='directory containing flag svg, '
+      'default %s' % DEFAULT_FLAGS_DIR, default=DEFAULT_FLAGS_DIR)
+  parser.add_argument(
+      '--emoji_dir', '-e', metavar='dir',
+      help='directory containing emoji svg, default %s' % DEFAULT_EMOJI_DIR,
+      default=DEFAULT_EMOJI_DIR)
+  parser.add_argument(
+      '-l', '--loglevel', help='log level name/value', default='warning')
+  args = parser.parse_args(argv)
+
+  tool_utils.setup_logging(args.loglevel)
+
+  args.flags_dir = tool_utils.resolve_path(args.flags_dir)
+  args.emoji_dir = tool_utils.resolve_path(args.emoji_dir)
+  build_svg_dir(
+      args.dst_dir, clean=args.clean, emoji_dir=args.emoji_dir,
+      flags_dir=args.flags_dir)
+
+
+if __name__ == '__main__':
+  main(sys.argv[1:])

--- a/linux/emoji_aliases.txt
+++ b/linux/emoji_aliases.txt
@@ -1,0 +1,263 @@
+# alias table
+# from;to
+# the 'from' sequence should be represented by the image for the 'to' sequence
+# 'fe0f' is not in these sequences
+1f3c3;1f3c3_200d_2642 # RUNNER -> man running
+1f3c3_1f3fb;1f3c3_1f3fb_200d_2642 # light skin tone
+1f3c3_1f3fc;1f3c3_1f3fc_200d_2642 # medium-light skin tone
+1f3c3_1f3fd;1f3c3_1f3fd_200d_2642 # medium skin tone
+1f3c3_1f3fe;1f3c3_1f3fe_200d_2642 # medium-dark skin tone
+1f3c3_1f3ff;1f3c3_1f3ff_200d_2642 # dark skin tone
+1f3c4;1f3c4_200d_2642 # SURFER -> man surfing
+1f3c4_1f3fb;1f3c4_1f3fb_200d_2642 # light skin tone
+1f3c4_1f3fc;1f3c4_1f3fc_200d_2642 # medium-light skin tone
+1f3c4_1f3fd;1f3c4_1f3fd_200d_2642 # medium skin tone
+1f3c4_1f3fe;1f3c4_1f3fe_200d_2642 # medium-dark skin tone
+1f3c4_1f3ff;1f3c4_1f3ff_200d_2642 # dark skin tone
+1f3ca;1f3ca_200d_2642 # SWIMMER -> man swimming
+1f3ca_1f3fb;1f3ca_1f3fb_200d_2642 # light skin tone
+1f3ca_1f3fc;1f3ca_1f3fc_200d_2642 # medium-light skin tone
+1f3ca_1f3fd;1f3ca_1f3fd_200d_2642 # medium skin tone
+1f3ca_1f3fe;1f3ca_1f3fe_200d_2642 # medium-dark skin tone
+1f3ca_1f3ff;1f3ca_1f3ff_200d_2642 # dark skin tone
+1f3cb;1f3cb_200d_2642 # WEIGHT LIFTER -> man lifting weights
+1f3cb_1f3fb;1f3cb_1f3fb_200d_2642 # light skin tone
+1f3cb_1f3fc;1f3cb_1f3fc_200d_2642 # medium-light skin tone
+1f3cb_1f3fd;1f3cb_1f3fd_200d_2642 # medium skin tone
+1f3cb_1f3fe;1f3cb_1f3fe_200d_2642 # medium-dark skin tone
+1f3cb_1f3ff;1f3cb_1f3ff_200d_2642 # dark skin tone
+1f3cc;1f3cc_200d_2642 # GOLFER -> man golfing
+1f3cc_1f3fb;1f3cc_1f3fb_200d_2642 # light skin tone
+1f3cc_1f3fc;1f3cc_1f3fc_200d_2642 # medium-light skin tone
+1f3cc_1f3fd;1f3cc_1f3fd_200d_2642 # medium skin tone
+1f3cc_1f3fe;1f3cc_1f3fe_200d_2642 # medium-dark skin tone
+1f3cc_1f3ff;1f3cc_1f3ff_200d_2642 # dark skin tone
+1f46a;1f468_200d_1f469_200d_1f466 # FAMILY -> family: man, woman, boy
+1f46e;1f46e_200d_2642 # POLICE OFFICER -> man police officer
+1f46e_1f3fb;1f46e_1f3fb_200d_2642 # light skin tone
+1f46e_1f3fc;1f46e_1f3fc_200d_2642 # medium-light skin tone
+1f46e_1f3fd;1f46e_1f3fd_200d_2642 # medium skin tone
+1f46e_1f3fe;1f46e_1f3fe_200d_2642 # medium-dark skin tone
+1f46e_1f3ff;1f46e_1f3ff_200d_2642 # dark skin tone
+1f46f;1f46f_200d_2640 # WOMAN WITH BUNNY EARS -> women with bunny ears partying
+1f471;1f471_200d_2642 # PERSON WITH BLOND HAIR -> blond-haired man
+1f471_1f3fb;1f471_1f3fb_200d_2642 # light skin tone
+1f471_1f3fc;1f471_1f3fc_200d_2642 # medium-light skin tone
+1f471_1f3fd;1f471_1f3fd_200d_2642 # medium skin tone
+1f471_1f3fe;1f471_1f3fe_200d_2642 # medium-dark skin tone
+1f471_1f3ff;1f471_1f3ff_200d_2642 # dark skin tone
+1f473;1f473_200d_2642 # MAN WITH TURBAN -> man wearing turban
+1f473_1f3fb;1f473_1f3fb_200d_2642 # light skin tone
+1f473_1f3fc;1f473_1f3fc_200d_2642 # medium-light skin tone
+1f473_1f3fd;1f473_1f3fd_200d_2642 # medium skin tone
+1f473_1f3fe;1f473_1f3fe_200d_2642 # medium-dark skin tone
+1f473_1f3ff;1f473_1f3ff_200d_2642 # dark skin tone
+1f477;1f477_200d_2642 # CONSTRUCTION WORKER -> man construction worker
+1f477_1f3fb;1f477_1f3fb_200d_2642 # light skin tone
+1f477_1f3fc;1f477_1f3fc_200d_2642 # medium-light skin tone
+1f477_1f3fd;1f477_1f3fd_200d_2642 # medium skin tone
+1f477_1f3fe;1f477_1f3fe_200d_2642 # medium-dark skin tone
+1f477_1f3ff;1f477_1f3ff_200d_2642 # dark skin tone
+1f481;1f481_200d_2640 # INFORMATION DESK PERSON -> woman tipping hand
+1f481_1f3fb;1f481_1f3fb_200d_2640 # light skin tone
+1f481_1f3fc;1f481_1f3fc_200d_2640 # medium-light skin tone
+1f481_1f3fd;1f481_1f3fd_200d_2640 # medium skin tone
+1f481_1f3fe;1f481_1f3fe_200d_2640 # medium-dark skin tone
+1f481_1f3ff;1f481_1f3ff_200d_2640 # dark skin tone
+1f482;1f482_200d_2642 # GUARDSMAN -> man guard
+1f482_1f3fb;1f482_1f3fb_200d_2642 # light skin tone
+1f482_1f3fc;1f482_1f3fc_200d_2642 # medium-light skin tone
+1f482_1f3fd;1f482_1f3fd_200d_2642 # medium skin tone
+1f482_1f3fe;1f482_1f3fe_200d_2642 # medium-dark skin tone
+1f482_1f3ff;1f482_1f3ff_200d_2642 # dark skin tone
+1f486;1f486_200d_2640 # FACE MASSAGE -> woman getting massage
+1f486_1f3fb;1f486_1f3fb_200d_2640 # light skin tone
+1f486_1f3fc;1f486_1f3fc_200d_2640 # medium-light skin tone
+1f486_1f3fd;1f486_1f3fd_200d_2640 # medium skin tone
+1f486_1f3fe;1f486_1f3fe_200d_2640 # medium-dark skin tone
+1f486_1f3ff;1f486_1f3ff_200d_2640 # dark skin tone
+1f487;1f487_200d_2640 # HAIRCUT -> woman getting haircut
+1f487_1f3fb;1f487_1f3fb_200d_2640 # light skin tone
+1f487_1f3fc;1f487_1f3fc_200d_2640 # medium-light skin tone
+1f487_1f3fd;1f487_1f3fd_200d_2640 # medium skin tone
+1f487_1f3fe;1f487_1f3fe_200d_2640 # medium-dark skin tone
+1f487_1f3ff;1f487_1f3ff_200d_2640 # dark skin tone
+1f48f;1f469_200d_2764_200d_1f48b_200d_1f468 # KISS -> kiss: woman, man
+1f491;1f469_200d_2764_200d_1f468 # COUPLE WITH HEART -> couple with heart: woman, man
+1f575;1f575_200d_2642 # SLEUTH OR SPY -> man detective
+1f575_1f3fb;1f575_1f3fb_200d_2642 # light skin tone
+1f575_1f3fc;1f575_1f3fc_200d_2642 # medium-light skin tone
+1f575_1f3fd;1f575_1f3fd_200d_2642 # medium skin tone
+1f575_1f3fe;1f575_1f3fe_200d_2642 # medium-dark skin tone
+1f575_1f3ff;1f575_1f3ff_200d_2642 # dark skin tone
+1f645;1f645_200d_2640 # FACE WITH NO GOOD GESTURE -> woman gesturing NO
+1f645_1f3fb;1f645_1f3fb_200d_2640 # light skin tone
+1f645_1f3fc;1f645_1f3fc_200d_2640 # medium-light skin tone
+1f645_1f3fd;1f645_1f3fd_200d_2640 # medium skin tone
+1f645_1f3fe;1f645_1f3fe_200d_2640 # medium-dark skin tone
+1f645_1f3ff;1f645_1f3ff_200d_2640 # dark skin tone
+1f646;1f646_200d_2640 # FACE WITH OK GESTURE -> woman gesturing OK
+1f646_1f3fb;1f646_1f3fb_200d_2640 # light skin tone
+1f646_1f3fc;1f646_1f3fc_200d_2640 # medium-light skin tone
+1f646_1f3fd;1f646_1f3fd_200d_2640 # medium skin tone
+1f646_1f3fe;1f646_1f3fe_200d_2640 # medium-dark skin tone
+1f646_1f3ff;1f646_1f3ff_200d_2640 # dark skin tone
+1f647;1f647_200d_2642 # PERSON BOWING DEEPLY -> man bowing
+1f647_1f3fb;1f647_1f3fb_200d_2642 # light skin tone
+1f647_1f3fc;1f647_1f3fc_200d_2642 # medium-light skin tone
+1f647_1f3fd;1f647_1f3fd_200d_2642 # medium skin tone
+1f647_1f3fe;1f647_1f3fe_200d_2642 # medium-dark skin tone
+1f647_1f3ff;1f647_1f3ff_200d_2642 # dark skin tone
+1f64b;1f64b_200d_2640 # HAPPY PERSON RAISING ONE HAND -> woman raising hand
+1f64b_1f3fb;1f64b_1f3fb_200d_2640 # light skin tone
+1f64b_1f3fc;1f64b_1f3fc_200d_2640 # medium-light skin tone
+1f64b_1f3fd;1f64b_1f3fd_200d_2640 # medium skin tone
+1f64b_1f3fe;1f64b_1f3fe_200d_2640 # medium-dark skin tone
+1f64b_1f3ff;1f64b_1f3ff_200d_2640 # dark skin tone
+1f64d;1f64d_200d_2640 # PERSON FROWNING -> woman frowning
+1f64d_1f3fb;1f64d_1f3fb_200d_2640 # light skin tone
+1f64d_1f3fc;1f64d_1f3fc_200d_2640 # medium-light skin tone
+1f64d_1f3fd;1f64d_1f3fd_200d_2640 # medium skin tone
+1f64d_1f3fe;1f64d_1f3fe_200d_2640 # medium-dark skin tone
+1f64d_1f3ff;1f64d_1f3ff_200d_2640 # dark skin tone
+1f64e;1f64e_200d_2640 # PERSON WITH POUTING FACE -> woman pouting
+1f64e_1f3fb;1f64e_1f3fb_200d_2640 # light skin tone
+1f64e_1f3fc;1f64e_1f3fc_200d_2640 # medium-light skin tone
+1f64e_1f3fd;1f64e_1f3fd_200d_2640 # medium skin tone
+1f64e_1f3fe;1f64e_1f3fe_200d_2640 # medium-dark skin tone
+1f64e_1f3ff;1f64e_1f3ff_200d_2640 # dark skin tone
+1f6a3;1f6a3_200d_2642 # ROWBOAT -> man rowing boat
+1f6a3_1f3fb;1f6a3_1f3fb_200d_2642 # light skin tone
+1f6a3_1f3fc;1f6a3_1f3fc_200d_2642 # medium-light skin tone
+1f6a3_1f3fd;1f6a3_1f3fd_200d_2642 # medium skin tone
+1f6a3_1f3fe;1f6a3_1f3fe_200d_2642 # medium-dark skin tone
+1f6a3_1f3ff;1f6a3_1f3ff_200d_2642 # dark skin tone
+1f6b4;1f6b4_200d_2642 # BICYCLIST -> man biking
+1f6b4_1f3fb;1f6b4_1f3fb_200d_2642 # light skin tone
+1f6b4_1f3fc;1f6b4_1f3fc_200d_2642 # medium-light skin tone
+1f6b4_1f3fd;1f6b4_1f3fd_200d_2642 # medium skin tone
+1f6b4_1f3fe;1f6b4_1f3fe_200d_2642 # medium-dark skin tone
+1f6b4_1f3ff;1f6b4_1f3ff_200d_2642 # dark skin tone
+1f6b5;1f6b5_200d_2642 # MOUNTAIN BICYCLIST -> man mountain biking
+1f6b5_1f3fb;1f6b5_1f3fb_200d_2642 # light skin tone
+1f6b5_1f3fc;1f6b5_1f3fc_200d_2642 # medium-light skin tone
+1f6b5_1f3fd;1f6b5_1f3fd_200d_2642 # medium skin tone
+1f6b5_1f3fe;1f6b5_1f3fe_200d_2642 # medium-dark skin tone
+1f6b5_1f3ff;1f6b5_1f3ff_200d_2642 # dark skin tone
+1f6b6;1f6b6_200d_2642 # PEDESTRIAN -> man walking
+1f6b6_1f3fb;1f6b6_1f3fb_200d_2642 # light skin tone
+1f6b6_1f3fc;1f6b6_1f3fc_200d_2642 # medium-light skin tone
+1f6b6_1f3fd;1f6b6_1f3fd_200d_2642 # medium skin tone
+1f6b6_1f3fe;1f6b6_1f3fe_200d_2642 # medium-dark skin tone
+1f6b6_1f3ff;1f6b6_1f3ff_200d_2642 # dark skin tone
+1f926;1f926_200d_2640 # FACE PALM -> woman facepalming
+1f926_1f3fb;1f926_1f3fb_200d_2640 # light skin tone
+1f926_1f3fc;1f926_1f3fc_200d_2640 # medium-light skin tone
+1f926_1f3fd;1f926_1f3fd_200d_2640 # medium skin tone
+1f926_1f3fe;1f926_1f3fe_200d_2640 # medium-dark skin tone
+1f926_1f3ff;1f926_1f3ff_200d_2640 # dark skin tone
+1f937;1f937_200d_2640 # SHRUG -> woman shrugging
+1f937_1f3fb;1f937_1f3fb_200d_2640 # light skin tone
+1f937_1f3fc;1f937_1f3fc_200d_2640 # medium-light skin tone
+1f937_1f3fd;1f937_1f3fd_200d_2640 # medium skin tone
+1f937_1f3fe;1f937_1f3fe_200d_2640 # medium-dark skin tone
+1f937_1f3ff;1f937_1f3ff_200d_2640 # dark skin tone
+1f938;1f938_200d_2642 # PERSON DOING CARTWHEEL -> man cartwheeling
+1f938_1f3fb;1f938_1f3fb_200d_2642 # light skin tone
+1f938_1f3fc;1f938_1f3fc_200d_2642 # medium-light skin tone
+1f938_1f3fd;1f938_1f3fd_200d_2642 # medium skin tone
+1f938_1f3fe;1f938_1f3fe_200d_2642 # medium-dark skin tone
+1f938_1f3ff;1f938_1f3ff_200d_2642 # dark skin tone
+1f939;1f939_200d_2642 # JUGGLING -> man juggling
+1f939_1f3fb;1f939_1f3fb_200d_2642 # light skin tone
+1f939_1f3fc;1f939_1f3fc_200d_2642 # medium-light skin tone
+1f939_1f3fd;1f939_1f3fd_200d_2642 # medium skin tone
+1f939_1f3fe;1f939_1f3fe_200d_2642 # medium-dark skin tone
+1f939_1f3ff;1f939_1f3ff_200d_2642 # dark skin tone
+1f93c;1f93c_200d_2642 # WRESTLERS -> men wrestling
+1f93d;1f93d_200d_2642 # WATER POLO -> man playing water polo
+1f93d_1f3fb;1f93d_1f3fb_200d_2642 # light skin tone
+1f93d_1f3fc;1f93d_1f3fc_200d_2642 # medium-light skin tone
+1f93d_1f3fd;1f93d_1f3fd_200d_2642 # medium skin tone
+1f93d_1f3fe;1f93d_1f3fe_200d_2642 # medium-dark skin tone
+1f93d_1f3ff;1f93d_1f3ff_200d_2642 # dark skin tone
+1f93e;1f93e_200d_2642 # HANDBALL -> man playing handball
+1f93e_1f3fb;1f93e_1f3fb_200d_2642 # light skin tone
+1f93e_1f3fc;1f93e_1f3fc_200d_2642 # medium-light skin tone
+1f93e_1f3fd;1f93e_1f3fd_200d_2642 # medium skin tone
+1f93e_1f3fe;1f93e_1f3fe_200d_2642 # medium-dark skin tone
+1f93e_1f3ff;1f93e_1f3ff_200d_2642 # dark skin tone
+26f9;26f9_200d_2642 # PERSON WITH BALL -> man bouncing ball
+26f9_1f3fb;26f9_1f3fb_200d_2642 # light skin tone
+26f9_1f3fc;26f9_1f3fc_200d_2642 # medium-light skin tone
+26f9_1f3fd;26f9_1f3fd_200d_2642 # medium skin tone
+26f9_1f3fe;26f9_1f3fe_200d_2642 # medium-dark skin tone
+26f9_1f3ff;26f9_1f3ff_200d_2642 # dark skin tone
+fe82b;unknown_flag # no name -> no name
+
+# flag aliases
+1f1e7_1f1fb;1f1f3_1f1f4 # BV -> NO
+1f1e8_1f1f5;1f1eb_1f1f7 # CP -> FR
+1f1ed_1f1f2;1f1e6_1f1fa # HM -> AU
+1f1f8_1f1ef;1f1f3_1f1f4 # SJ -> NO
+1f1fa_1f1f2;1f1fa_1f1f8 # UM -> US
+
+# additional emoji 5.0 aliases
+1f9d6;1f9d6_200d_2640 # PERSON IN STEAMY ROOM -> woman in steamy room
+1f9d6_1f3fb;1f9d6_1f3fb_200d_2640 # light skin tone
+1f9d6_1f3fc;1f9d6_1f3fc_200d_2640 # medium-light skin tone
+1f9d6_1f3fd;1f9d6_1f3fd_200d_2640 # medium skin tone
+1f9d6_1f3fe;1f9d6_1f3fe_200d_2640 # medium-dark skin tone
+1f9d6_1f3ff;1f9d6_1f3ff_200d_2640 # dark skin tone
+1f9d7;1f9d7_200d_2640 # PERSON CLIMBING -> woman climbing
+1f9d7_1f3fb;1f9d7_1f3fb_200d_2640 # light skin tone
+1f9d7_1f3fc;1f9d7_1f3fc_200d_2640 # medium-light skin tone
+1f9d7_1f3fd;1f9d7_1f3fd_200d_2640 # medium skin tone
+1f9d7_1f3fe;1f9d7_1f3fe_200d_2640 # medium-dark skin tone
+1f9d7_1f3ff;1f9d7_1f3ff_200d_2640 # dark skin tone
+1f9d8;1f9d8_200d_2640 # PERSON IN LOTUS POSITION -> woman in lotus position
+1f9d8_1f3fb;1f9d8_1f3fb_200d_2640 # light skin tone
+1f9d8_1f3fc;1f9d8_1f3fc_200d_2640 # medium-light skin tone
+1f9d8_1f3fd;1f9d8_1f3fd_200d_2640 # medium skin tone
+1f9d8_1f3fe;1f9d8_1f3fe_200d_2640 # medium-dark skin tone
+1f9d8_1f3ff;1f9d8_1f3ff_200d_2640 # dark skin tone
+1f9d9;1f9d9_200d_2640 # MAGE -> female mage
+1f9d9_1f3fb;1f9d9_1f3fb_200d_2640 # light skin tone
+1f9d9_1f3fc;1f9d9_1f3fc_200d_2640 # medium-light skin tone
+1f9d9_1f3fd;1f9d9_1f3fd_200d_2640 # medium skin tone
+1f9d9_1f3fe;1f9d9_1f3fe_200d_2640 # medium-dark skin tone
+1f9d9_1f3ff;1f9d9_1f3ff_200d_2640 # dark skin tone
+1f9da;1f9da_200d_2640 # FAIRY -> female fairy
+1f9da_1f3fb;1f9da_1f3fb_200d_2640 # light skin tone
+1f9da_1f3fc;1f9da_1f3fc_200d_2640 # medium-light skin tone
+1f9da_1f3fd;1f9da_1f3fd_200d_2640 # medium skin tone
+1f9da_1f3fe;1f9da_1f3fe_200d_2640 # medium-dark skin tone
+1f9da_1f3ff;1f9da_1f3ff_200d_2640 # dark skin tone
+1f9db;1f9db_200d_2640 # VAMPIRE -> female vampire
+1f9db_1f3fb;1f9db_1f3fb_200d_2640 # light skin tone
+1f9db_1f3fc;1f9db_1f3fc_200d_2640 # medium-light skin tone
+1f9db_1f3fd;1f9db_1f3fd_200d_2640 # medium skin tone
+1f9db_1f3fe;1f9db_1f3fe_200d_2640 # medium-dark skin tone
+1f9db_1f3ff;1f9db_1f3ff_200d_2640 # dark skin tone
+1f9dc;1f9dc_200d_2640 # MERPERSON -> mermaid
+1f9dc_1f3fb;1f9dc_1f3fb_200d_2640 # light skin tone
+1f9dc_1f3fc;1f9dc_1f3fc_200d_2640 # medium-light skin tone
+1f9dc_1f3fd;1f9dc_1f3fd_200d_2640 # medium skin tone
+1f9dc_1f3fe;1f9dc_1f3fe_200d_2640 # medium-dark skin tone
+1f9dc_1f3ff;1f9dc_1f3ff_200d_2640 # dark skin tone
+1f9dd;1f9dd_200d_2640 # ELF -> female elf
+1f9dd_1f3fb;1f9dd_1f3fb_200d_2640 # light skin tone
+1f9dd_1f3fc;1f9dd_1f3fc_200d_2640 # medium-light skin tone
+1f9dd_1f3fd;1f9dd_1f3fd_200d_2640 # medium skin tone
+1f9dd_1f3fe;1f9dd_1f3fe_200d_2640 # medium-dark skin tone
+1f9dd_1f3ff;1f9dd_1f3ff_200d_2640 # dark skin tone
+1f9de;1f9de_200d_2640 # GENIE -> female genie
+1f9df;1f9df_200d_2640 # ZOMBIE -> female zombie
+
+# legacy android sequences
+# wrestlers -> men wrestling
+1f93c_1f3fb;1f93c_1f3fb_200d_2642 # light skin tone
+1f93c_1f3fc;1f93c_1f3fc_200d_2642 # medium-light skin tone
+1f93c_1f3fd;1f93c_1f3fd_200d_2642 # medium skin tone
+1f93c_1f3fe;1f93c_1f3fe_200d_2642 # medium-dark skin tone
+1f93c_1f3ff;1f93c_1f3ff_200d_2642 # dark skin tone

--- a/linux/emoji_annotations.txt
+++ b/linux/emoji_annotations.txt
@@ -1,0 +1,458 @@
+# annotations
+###
+### aliases
+###
+annotation: ok
+1f3c3 # RUNNER -> man running
+1f3c3 1f3fb # light skin tone
+1f3c3 1f3fc # medium-light skin tone
+1f3c3 1f3fd # medium skin tone
+1f3c3 1f3fe # medium-dark skin tone
+1f3c3 1f3ff # dark skin tone
+1f3c4 # SURFER -> man surfing
+1f3c4 1f3fb # light skin tone
+1f3c4 1f3fc # medium-light skin tone
+1f3c4 1f3fd # medium skin tone
+1f3c4 1f3fe # medium-dark skin tone
+1f3c4 1f3ff # dark skin tone
+1f3ca # SWIMMER -> man swimming
+1f3ca 1f3fb # light skin tone
+1f3ca 1f3fc # medium-light skin tone
+1f3ca 1f3fd # medium skin tone
+1f3ca 1f3fe # medium-dark skin tone
+1f3ca 1f3ff # dark skin tone
+1f3cb # WEIGHT LIFTER -> man lifting weights
+1f3cb 1f3fb # light skin tone
+1f3cb 1f3fc # medium-light skin tone
+1f3cb 1f3fd # medium skin tone
+1f3cb 1f3fe # medium-dark skin tone
+1f3cb 1f3ff # dark skin tone
+1f3cc # GOLFER -> man golfing
+1f3cc 1f3fb # light skin tone
+1f3cc 1f3fc # medium-light skin tone
+1f3cc 1f3fd # medium skin tone
+1f3cc 1f3fe # medium-dark skin tone
+1f3cc 1f3ff # dark skin tone
+1f46a # FAMILY -> family: man, woman, boy
+1f46e # POLICE OFFICER -> man police officer
+1f46e 1f3fb # light skin tone
+1f46e 1f3fc # medium-light skin tone
+1f46e 1f3fd # medium skin tone
+1f46e 1f3fe # medium-dark skin tone
+1f46e 1f3ff # dark skin tone
+1f46f # WOMAN WITH BUNNY EARS -> women with bunny ears partying
+1f471 # PERSON WITH BLOND HAIR -> blond-haired man
+1f471 1f3fb # light skin tone
+1f471 1f3fc # medium-light skin tone
+1f471 1f3fd # medium skin tone
+1f471 1f3fe # medium-dark skin tone
+1f471 1f3ff # dark skin tone
+1f473 # MAN WITH TURBAN -> man wearing turban
+1f473 1f3fb # light skin tone
+1f473 1f3fc # medium-light skin tone
+1f473 1f3fd # medium skin tone
+1f473 1f3fe # medium-dark skin tone
+1f473 1f3ff # dark skin tone
+1f477 # CONSTRUCTION WORKER -> man construction worker
+1f477 1f3fb # light skin tone
+1f477 1f3fc # medium-light skin tone
+1f477 1f3fd # medium skin tone
+1f477 1f3fe # medium-dark skin tone
+1f477 1f3ff # dark skin tone
+1f481 # INFORMATION DESK PERSON -> woman tipping hand
+1f481 1f3fb # light skin tone
+1f481 1f3fc # medium-light skin tone
+1f481 1f3fd # medium skin tone
+1f481 1f3fe # medium-dark skin tone
+1f481 1f3ff # dark skin tone
+1f482 # GUARDSMAN -> man guard
+1f482 1f3fb # light skin tone
+1f482 1f3fc # medium-light skin tone
+1f482 1f3fd # medium skin tone
+1f482 1f3fe # medium-dark skin tone
+1f482 1f3ff # dark skin tone
+1f486 # FACE MASSAGE -> woman getting massage
+1f486 1f3fb # light skin tone
+1f486 1f3fc # medium-light skin tone
+1f486 1f3fd # medium skin tone
+1f486 1f3fe # medium-dark skin tone
+1f486 1f3ff # dark skin tone
+1f487 # HAIRCUT -> woman getting haircut
+1f487 1f3fb # light skin tone
+1f487 1f3fc # medium-light skin tone
+1f487 1f3fd # medium skin tone
+1f487 1f3fe # medium-dark skin tone
+1f487 1f3ff # dark skin tone
+1f48f # KISS -> kiss: woman, man
+1f491 # COUPLE WITH HEART -> couple with heart: woman, man
+1f575 # SLEUTH OR SPY -> man detective
+1f575 1f3fb # light skin tone
+1f575 1f3fc # medium-light skin tone
+1f575 1f3fd # medium skin tone
+1f575 1f3fe # medium-dark skin tone
+1f575 1f3ff # dark skin tone
+1f645 # FACE WITH NO GOOD GESTURE -> woman gesturing NO
+1f645 1f3fb # light skin tone
+1f645 1f3fc # medium-light skin tone
+1f645 1f3fd # medium skin tone
+1f645 1f3fe # medium-dark skin tone
+1f645 1f3ff # dark skin tone
+1f646 # FACE WITH OK GESTURE -> woman gesturing OK
+1f646 1f3fb # light skin tone
+1f646 1f3fc # medium-light skin tone
+1f646 1f3fd # medium skin tone
+1f646 1f3fe # medium-dark skin tone
+1f646 1f3ff # dark skin tone
+1f647 # PERSON BOWING DEEPLY -> man bowing
+1f647 1f3fb # light skin tone
+1f647 1f3fc # medium-light skin tone
+1f647 1f3fd # medium skin tone
+1f647 1f3fe # medium-dark skin tone
+1f647 1f3ff # dark skin tone
+1f64b # HAPPY PERSON RAISING ONE HAND -> woman raising hand
+1f64b 1f3fb # light skin tone
+1f64b 1f3fc # medium-light skin tone
+1f64b 1f3fd # medium skin tone
+1f64b 1f3fe # medium-dark skin tone
+1f64b 1f3ff # dark skin tone
+1f64d # PERSON FROWNING -> woman frowning
+1f64d 1f3fb # light skin tone
+1f64d 1f3fc # medium-light skin tone
+1f64d 1f3fd # medium skin tone
+1f64d 1f3fe # medium-dark skin tone
+1f64d 1f3ff # dark skin tone
+1f64e # PERSON WITH POUTING FACE -> woman pouting
+1f64e 1f3fb # light skin tone
+1f64e 1f3fc # medium-light skin tone
+1f64e 1f3fd # medium skin tone
+1f64e 1f3fe # medium-dark skin tone
+1f64e 1f3ff # dark skin tone
+1f6a3 # ROWBOAT -> man rowing boat
+1f6a3 1f3fb # light skin tone
+1f6a3 1f3fc # medium-light skin tone
+1f6a3 1f3fd # medium skin tone
+1f6a3 1f3fe # medium-dark skin tone
+1f6a3 1f3ff # dark skin tone
+1f6b4 # BICYCLIST -> man biking
+1f6b4 1f3fb # light skin tone
+1f6b4 1f3fc # medium-light skin tone
+1f6b4 1f3fd # medium skin tone
+1f6b4 1f3fe # medium-dark skin tone
+1f6b4 1f3ff # dark skin tone
+1f6b5 # MOUNTAIN BICYCLIST -> man mountain biking
+1f6b5 1f3fb # light skin tone
+1f6b5 1f3fc # medium-light skin tone
+1f6b5 1f3fd # medium skin tone
+1f6b5 1f3fe # medium-dark skin tone
+1f6b5 1f3ff # dark skin tone
+1f6b6 # PEDESTRIAN -> man walking
+1f6b6 1f3fb # light skin tone
+1f6b6 1f3fc # medium-light skin tone
+1f6b6 1f3fd # medium skin tone
+1f6b6 1f3fe # medium-dark skin tone
+1f6b6 1f3ff # dark skin tone
+1f926 # FACE PALM -> woman facepalming
+1f926 1f3fb # light skin tone
+1f926 1f3fc # medium-light skin tone
+1f926 1f3fd # medium skin tone
+1f926 1f3fe # medium-dark skin tone
+1f926 1f3ff # dark skin tone
+1f937 # SHRUG -> woman shrugging
+1f937 1f3fb # light skin tone
+1f937 1f3fc # medium-light skin tone
+1f937 1f3fd # medium skin tone
+1f937 1f3fe # medium-dark skin tone
+1f937 1f3ff # dark skin tone
+1f938 # PERSON DOING CARTWHEEL -> man cartwheeling
+1f938 1f3fb # light skin tone
+1f938 1f3fc # medium-light skin tone
+1f938 1f3fd # medium skin tone
+1f938 1f3fe # medium-dark skin tone
+1f938 1f3ff # dark skin tone
+1f939 # JUGGLING -> man juggling
+1f939 1f3fb # light skin tone
+1f939 1f3fc # medium-light skin tone
+1f939 1f3fd # medium skin tone
+1f939 1f3fe # medium-dark skin tone
+1f939 1f3ff # dark skin tone
+1f93c # WRESTLERS -> men wrestling
+1f93d # WATER POLO -> man playing water polo
+1f93d 1f3fb # light skin tone
+1f93d 1f3fc # medium-light skin tone
+1f93d 1f3fd # medium skin tone
+1f93d 1f3fe # medium-dark skin tone
+1f93d 1f3ff # dark skin tone
+1f93e # HANDBALL -> man playing handball
+1f93e 1f3fb # light skin tone
+1f93e 1f3fc # medium-light skin tone
+1f93e 1f3fd # medium skin tone
+1f93e 1f3fe # medium-dark skin tone
+1f93e 1f3ff # dark skin tone
+26f9 # PERSON WITH BALL -> man bouncing ball
+26f9 1f3fb # light skin tone
+26f9 1f3fc # medium-light skin tone
+26f9 1f3fd # medium skin tone
+26f9 1f3fe # medium-dark skin tone
+26f9 1f3ff # dark skin tone
+fe82b # no name -> no name
+
+# flag aliases
+1f1e7 1f1fb # BV -> NO
+1f1e8 1f1f5 # CP -> FR
+1f1ed 1f1f2 # HM -> AU
+1f1f8 1f1ef # SJ -> NO
+1f1fa 1f1f2 # UM -> US
+
+###
+### unwanted flags
+###
+annotation: error
+1f1e7 1f1f1
+1f1e7 1f1f6
+1f1e9 1f1ec
+1f1ea 1f1e6
+1f1ea 1f1ed
+1f1eb 1f1f0
+1f1ec 1f1eb
+1f1ec 1f1f5
+1f1ec 1f1f8
+1f1f2 1f1eb
+1f1f2 1f1f6
+1f1f3 1f1e8
+1f1f5 1f1f2
+1f1f7 1f1ea
+1f1f9 1f1eb
+1f1fc 1f1eb
+1f1fd 1f1f0
+1f1fe 1f1f9
+
+###
+### new emoji
+###
+annotation: warning
+1f6f7
+1f6f8
+1f91f
+1f91f 1f3fb
+1f91f 1f3fc
+1f91f 1f3fd
+1f91f 1f3fe
+1f91f 1f3ff
+1f928
+1f929
+1f92a
+1f92b
+1f92c
+1f92d
+1f92e
+1f92f
+1f931
+1f931 1f3fb
+1f931 1f3fc
+1f931 1f3fd
+1f931 1f3fe
+1f931 1f3ff
+1f932
+1f932 1f3fb
+1f932 1f3fc
+1f932 1f3fd
+1f932 1f3fe
+1f932 1f3ff
+1f94c
+1f961
+1f962
+1f964
+1f965
+1f966
+1f995
+1f996
+1f997
+1f9d0
+1f9d1
+1f9d1 1f3fb
+1f9d1 1f3fc
+1f9d1 1f3fd
+1f9d1 1f3fe
+1f9d1 1f3ff
+1f9d2
+1f9d2 1f3fb
+1f9d2 1f3fc
+1f9d2 1f3fd
+1f9d2 1f3fe
+1f9d2 1f3ff
+1f9d3
+1f9d3 1f3fb
+1f9d3 1f3fc
+1f9d3 1f3fd
+1f9d3 1f3fe
+1f9d3 1f3ff
+1f9d4
+1f9d4 1f3fb
+1f9d4 1f3fc
+1f9d4 1f3fd
+1f9d4 1f3fe
+1f9d4 1f3ff
+1f9d5
+1f9d5 1f3fb
+1f9d5 1f3fc
+1f9d5 1f3fd
+1f9d5 1f3fe
+1f9d5 1f3ff
+1f9d6
+1f9d6 1f3fb
+1f9d6 1f3fc
+1f9d6 1f3fd
+1f9d6 1f3fe
+1f9d6 1f3ff
+1f9d6 200d 2640
+1f9d6 1f3fb 200d 2640
+1f9d6 1f3fc 200d 2640
+1f9d6 1f3fd 200d 2640
+1f9d6 1f3fe 200d 2640
+1f9d6 1f3ff 200d 2640
+1f9d6 200d 2642
+1f9d6 1f3fb 200d 2642
+1f9d6 1f3fc 200d 2642
+1f9d6 1f3fd 200d 2642
+1f9d6 1f3fe 200d 2642
+1f9d6 1f3ff 200d 2642
+1f9d7
+1f9d7 1f3fb
+1f9d7 1f3fc
+1f9d7 1f3fd
+1f9d7 1f3fe
+1f9d7 1f3ff
+1f9d7 200d 2640
+1f9d7 1f3fb 200d 2640
+1f9d7 1f3fc 200d 2640
+1f9d7 1f3fd 200d 2640
+1f9d7 1f3fe 200d 2640
+1f9d7 1f3ff 200d 2640
+1f9d7 200d 2642
+1f9d7 1f3fb 200d 2642
+1f9d7 1f3fc 200d 2642
+1f9d7 1f3fd 200d 2642
+1f9d7 1f3fe 200d 2642
+1f9d7 1f3ff 200d 2642
+1f9d8
+1f9d8 1f3fb
+1f9d8 1f3fc
+1f9d8 1f3fd
+1f9d8 1f3fe
+1f9d8 1f3ff
+1f9d8 200d 2640
+1f9d8 1f3fb 200d 2640
+1f9d8 1f3fc 200d 2640
+1f9d8 1f3fd 200d 2640
+1f9d8 1f3fe 200d 2640
+1f9d8 1f3ff 200d 2640
+1f9d8 200d 2642
+1f9d8 1f3fb 200d 2642
+1f9d8 1f3fc 200d 2642
+1f9d8 1f3fd 200d 2642
+1f9d8 1f3fe 200d 2642
+1f9d8 1f3ff 200d 2642
+1f9d9
+1f9d9 1f3fb
+1f9d9 1f3fc
+1f9d9 1f3fd
+1f9d9 1f3fe
+1f9d9 1f3ff
+1f9d9 200d 2640
+1f9d9 1f3fb 200d 2640
+1f9d9 1f3fc 200d 2640
+1f9d9 1f3fd 200d 2640
+1f9d9 1f3fe 200d 2640
+1f9d9 1f3ff 200d 2640
+1f9d9 200d 2642
+1f9d9 1f3fb 200d 2642
+1f9d9 1f3fc 200d 2642
+1f9d9 1f3fd 200d 2642
+1f9d9 1f3fe 200d 2642
+1f9d9 1f3ff 200d 2642
+1f9da
+1f9da 1f3fb
+1f9da 1f3fc
+1f9da 1f3fd
+1f9da 1f3fe
+1f9da 1f3ff
+1f9da 200d 2640
+1f9da 1f3fb 200d 2640
+1f9da 1f3fc 200d 2640
+1f9da 1f3fd 200d 2640
+1f9da 1f3fe 200d 2640
+1f9da 1f3ff 200d 2640
+1f9da 200d 2642
+1f9da 1f3fb 200d 2642
+1f9da 1f3fc 200d 2642
+1f9da 1f3fd 200d 2642
+1f9da 1f3fe 200d 2642
+1f9da 1f3ff 200d 2642
+1f9db
+1f9db 1f3fb
+1f9db 1f3fc
+1f9db 1f3fd
+1f9db 1f3fe
+1f9db 1f3ff
+1f9db 200d 2640
+1f9db 1f3fb 200d 2640
+1f9db 1f3fc 200d 2640
+1f9db 1f3fd 200d 2640
+1f9db 1f3fe 200d 2640
+1f9db 1f3ff 200d 2640
+1f9db 200d 2642
+1f9db 1f3fb 200d 2642
+1f9db 1f3fc 200d 2642
+1f9db 1f3fd 200d 2642
+1f9db 1f3fe 200d 2642
+1f9db 1f3ff 200d 2642
+1f9dc
+1f9dc 1f3fb
+1f9dc 1f3fc
+1f9dc 1f3fd
+1f9dc 1f3fe
+1f9dc 1f3ff
+1f9dc 200d 2640
+1f9dc 1f3fb 200d 2640
+1f9dc 1f3fc 200d 2640
+1f9dc 1f3fd 200d 2640
+1f9dc 1f3fe 200d 2640
+1f9dc 1f3ff 200d 2640
+1f9dc 200d 2642
+1f9dc 1f3fb 200d 2642
+1f9dc 1f3fc 200d 2642
+1f9dc 1f3fd 200d 2642
+1f9dc 1f3fe 200d 2642
+1f9dc 1f3ff 200d 2642
+1f9dd
+1f9dd 1f3fb
+1f9dd 1f3fc
+1f9dd 1f3fd
+1f9dd 1f3fe
+1f9dd 1f3ff
+1f9dd 200d 2640
+1f9dd 1f3fb 200d 2640
+1f9dd 1f3fc 200d 2640
+1f9dd 1f3fd 200d 2640
+1f9dd 1f3fe 200d 2640
+1f9dd 1f3ff 200d 2640
+1f9dd 200d 2642
+1f9dd 1f3fb 200d 2642
+1f9dd 1f3fc 200d 2642
+1f9dd 1f3fd 200d 2642
+1f9dd 1f3fe 200d 2642
+1f9dd 1f3ff 200d 2642
+1f9de
+1f9de 200d 2640
+1f9de 200d 2642
+1f9df
+1f9df 200d 2640
+1f9df 200d 2642
+1f9e0
+1f9e1
+1f9e2
+1f9e3
+1f9e4
+1f9e5
+1f9e6
+

--- a/linux/gen_version.py
+++ b/linux/gen_version.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+#
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate version string for NotoColorEmoji.
+
+This parses the color emoji template file and updates the lines
+containing version string info, writing a new file.
+
+The nameID 5 field in the emoji font should reflect the commit/date
+of the repo it was built from.  This will build a string of the following
+format:
+  Version 1.39;GOOG;noto-emoji:20170220:a8a215d2e889'
+
+This is intended to indicate that it was built by Google from noto-emoji
+at commit a8a215d2e889 and date 20170220 (since dates are a bit easier
+to locate in time than commit hashes).
+
+For building with external data we don't include the commit id as we
+might be using different resoruces.  Instead the version string is:
+  Version 1.39;GOOG;noto-emoji:20170518;BETA <msg>
+
+Here the date is the current date, and the message after 'BETA ' is
+provided using the '-b' flag.  There's no commit hash.  This also
+bypasses some checks about the state of the repo.
+
+The relase number should have 2 or 3 minor digits.  Right now we've been
+using 2 but at the next major relase we probably want to use 3.  This
+supports both.  It will bump the version number if none is provided,
+maintaining the minor digit length.
+"""
+
+import argparse
+import datetime
+import re
+
+from nototools import tool_utils
+
+# These are not very lenient, we expect to be applied to the noto color
+# emoji template ttx file which matches these.  Why then require the
+# input argument, you ask?  Um... testing?
+_nameid_re = re.compile(r'\s*<namerecord nameID="5"')
+_version_re = re.compile(r'\s*Version\s(\d+.\d{2,3})')
+_headrev_re = re.compile(r'\s*<fontRevision value="(\d+.\d{2,3})"/>')
+
+def _get_existing_version(lines):
+  """Scan lines for all existing version numbers, and ensure they match.
+  Return the matched version number string."""
+
+  version = None
+  def check_version(new_version):
+    if version is not None and new_version != version:
+      raise Exception(
+          'version %s and namerecord version %s do not match' % (
+              version, new_version))
+    return new_version
+
+  saw_nameid = False
+  for line in lines:
+    if saw_nameid:
+      saw_nameid = False
+      m = _version_re.match(line)
+      if not m:
+        raise Exception('could not match line "%s" in namerecord' % line)
+      version = check_version(m.group(1))
+    elif _nameid_re.match(line):
+      saw_nameid = True
+    else:
+      m = _headrev_re.match(line)
+      if m:
+        version = check_version(m.group(1))
+  return version
+
+
+def _version_to_mm(version):
+  majs, mins = version.split('.')
+  minor_len = len(mins)
+  return int(majs), int(mins), minor_len
+
+
+def _mm_to_version(major, minor, minor_len):
+  fmt = '%%d.%%0%dd' % minor_len
+  return fmt % (major, minor)
+
+
+def _version_compare(lhs, rhs):
+  lmaj, lmin, llen = _version_to_mm(lhs)
+  rmaj, rmin, rlen = _version_to_mm(rhs)
+  # if major versions differ, we don't care about the minor length, else
+  # they should be the same
+  if lmaj != rmaj:
+    return lmaj - rmaj
+  if llen != rlen:
+    raise Exception('minor version lengths differ: "%s" and "%s"' % (lhs, rhs))
+  return lmin - rmin
+
+
+def _version_bump(version):
+  major, minor, minor_len = _version_to_mm(version)
+  minor = (minor + 1) % (10 ** minor_len)
+  if minor == 0:
+    raise Exception('cannot bump version "%s", requires new major' % version)
+  return _mm_to_version(major, minor, minor_len)
+
+
+def _get_repo_version_str(beta):
+  """See above for description of this string."""
+  if beta is not None:
+    date_str = datetime.date.today().strftime('%Y%m%d')
+    return 'GOOG;noto-emoji:%s;BETA %s' % (date_str, beta)
+
+  p = tool_utils.resolve_path('[emoji]')
+  commit, date, _ = tool_utils.git_head_commit(p)
+  if not tool_utils.git_check_remote_commit(p, commit):
+    raise Exception('emoji not on upstream master branch')
+  date_re = re.compile(r'(\d{4})-(\d{2})-(\d{2})')
+  m = date_re.match(date)
+  if not m:
+    raise Exception('could not match "%s" with "%s"' % (date, date_re.pattern))
+  ymd = ''.join(m.groups())
+  return 'GOOG;noto-emoji:%s:%s' % (ymd, commit[:12])
+
+
+def _replace_existing_version(lines, version, version_str):
+  """Update lines with new version strings in appropriate places."""
+  saw_nameid = False
+  for i in range(len(lines)):
+    line = lines[i]
+    if saw_nameid:
+      saw_nameid = False
+      # preserve indentation
+      lead_ws = len(line) - len(line.lstrip())
+      lines[i] = line[:lead_ws] + version_str + '\n'
+    elif _nameid_re.match(line):
+      saw_nameid = True
+    elif _headrev_re.match(line):
+      lead_ws = len(line) - len(line.lstrip())
+      lines[i] = line[:lead_ws] + '<fontRevision value="%s"/>\n' % version
+
+
+def update_version(srcfile, dstfile, version, beta):
+  """Update version in srcfile and write to dstfile.  If version is None,
+  bumps the current version, else version must be greater than the
+  current verison."""
+
+  with open(srcfile, 'r') as f:
+    lines = f.readlines()
+  current_version = _get_existing_version(lines)
+  if not version:
+    version = _version_bump(current_version)
+  elif version and _version_compare(version, current_version) <= 0:
+    raise Exception('new version %s is <= current version %s' % (
+        version, current_version))
+  version_str = 'Version %s;%s' % (version, _get_repo_version_str(beta))
+  _replace_existing_version(lines, version, version_str)
+  with open(dstfile, 'w') as f:
+    for line in lines:
+      f.write(line)
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '-v', '--version', help='version number, default bumps the current '
+      'version', metavar='ver')
+  parser.add_argument(
+      '-s', '--src', help='ttx file with name and head tables',
+      metavar='file', required=True)
+  parser.add_argument(
+      '-d', '--dst', help='name of edited ttx file to write',
+      metavar='file', required=True)
+  parser.add_argument(
+      '-b', '--beta', help='beta tag if font is built using external resources')
+  args = parser.parse_args()
+
+  update_version(args.src, args.dst, args.version, args.beta)
+
+
+if __name__ == '__main__':
+  main()

--- a/linux/generate_emoji_html.py
+++ b/linux/generate_emoji_html.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build an html page showing emoji images.
+
+This takes a list of directories containing emoji image files, and
+builds an html page presenting the images along with their composition
+(for sequences) and unicode names (for individual emoji)."""
+from __future__ import print_function
+
+import argparse
+import codecs
+import collections
+import datetime
+import glob
+import os
+from os import path
+import re
+import shutil
+import string
+import sys
+
+from nototools import tool_utils
+from nototools import unicode_data
+
+import add_aliases
+
+_default_dir = 'png/128'
+_default_ext = 'png'
+_default_prefix = 'emoji_u'
+_default_title = 'Emoji List'
+
+# DirInfo represents information about a directory of file names.
+# - directory is the directory path
+# - title is the title to use for this directory
+# - filemap is a dict mapping from a tuple of codepoints to the name of
+#   a file in the directory.
+DirInfo = collections.namedtuple('DirInfo', 'directory, title, filemap')
+
+
+def _merge_keys(dicts):
+  """Return the union of the keys in the list of dicts."""
+  keys = []
+  for d in dicts:
+    keys.extend(d.keys())
+  return frozenset(keys)
+
+
+def _generate_row_cells(
+    key, font, aliases, excluded, dir_infos, basepaths, colors):
+  CELL_PREFIX = '<td>'
+  indices = range(len(basepaths))
+  def _cell(info, basepath):
+    if key in info.filemap:
+      return '<img src="%s">' % path.join(basepath, info.filemap[key])
+    if key in aliases:
+      return 'alias'
+    if key in excluded:
+      return 'exclude'
+    return 'missing'
+
+  def _text_cell(text_dir):
+    text = ''.join(unichr(cp) for cp in key)
+    return '<span class="efont" dir="%s">%s</span>' % (text_dir, text)
+
+  if font:
+    row_cells = [
+        CELL_PREFIX + _text_cell(text_dir)
+        for text_dir in ('ltr', 'rtl')]
+  else:
+    row_cells = []
+  row_cells.extend(
+      [CELL_PREFIX + _cell(dir_infos[i], basepaths[i])
+       for i in indices])
+  if len(colors) > 1:
+    ix = indices[-1]
+    extension = CELL_PREFIX + _cell(dir_infos[ix], basepaths[ix])
+    row_cells.extend([extension] * (len(colors) - 1))
+  return row_cells
+
+
+def _get_desc(key_tuple, aliases, dir_infos, basepaths):
+  CELL_PREFIX = '<td>'
+  def _get_filepath(cp):
+    def get_key_filepath(key):
+      for i in range(len(dir_infos)):
+        info = dir_infos[i]
+        if key in info.filemap:
+          basepath = basepaths[i]
+          return path.join(basepath, info.filemap[key])
+      return None
+
+    cp_key = tuple([cp])
+    cp_key = unicode_data.get_canonical_emoji_sequence(cp_key) or cp_key
+    fp = get_key_filepath(cp_key)
+    if not fp:
+      if cp_key in aliases:
+        fp = get_key_filepath(aliases[cp_key])
+      else:
+        print('no alias for %s' % unicode_data.seq_to_string(cp_key))
+    if not fp:
+      print('no part for %s in %s' % (
+          unicode_data.seq_to_string(cp_key),
+          unicode_data.seq_to_string(key_tuple)))
+    return fp
+
+  def _get_part(cp):
+    if cp == 0x200d:  # zwj, common so replace with '+'
+      return '+'
+    if unicode_data.is_regional_indicator(cp):
+      return unicode_data.regional_indicator_to_ascii(cp)
+    if unicode_data.is_tag(cp):
+      return unicode_data.tag_character_to_ascii(cp)
+    fname = _get_filepath(cp)
+    if fname:
+      return '<img src="%s">' % fname
+    raise Exception()
+
+  if len(key_tuple) == 1:
+    desc = '%04x' % key_tuple
+  else:
+    desc = ' '.join('%04x' % cp for cp in key_tuple)
+    if len(unicode_data.strip_emoji_vs(key_tuple)) > 1:
+      try:
+        desc += ' (%s)' % ''.join(
+            _get_part(cp) for cp in key_tuple if cp != 0xfe0f)
+      except:
+        pass
+  return CELL_PREFIX + desc
+
+
+def _get_name(key_tuple, annotations):
+  annotation = None if annotations is None else annotations.get(key_tuple)
+  CELL_PREFIX = '<td%s>' % (
+      '' if annotation is None else ' class="%s"' % annotation)
+
+  seq_name = unicode_data.get_emoji_sequence_name(key_tuple)
+  if seq_name == None:
+    if key_tuple == (0x20e3,):
+      seq_name = '(combining enlosing keycap)'
+    elif key_tuple == (0xfe82b,):
+      seq_name = '(unknown flag PUA codepoint)'
+    else:
+      print('no name for %s' % unicode_data.seq_to_string(key_tuple))
+      seq_name = '(oops)'
+  return CELL_PREFIX + seq_name
+
+
+def _collect_aux_info(dir_infos, keys):
+  """Returns a map from dir_info_index to a set of keys of additional images
+  that we will take from the directory at that index."""
+
+  target_key_to_info_index = {}
+  for key in keys:
+    if len(key) == 1:
+      continue
+    for cp in key:
+      target_key = tuple([cp])
+      if target_key in keys or target_key in target_key_to_info_index:
+        continue
+      for i, info in enumerate(dir_infos):
+        if target_key in info.filemap:
+          target_key_to_info_index[target_key] = i
+          break
+      if target_key not in target_key_to_info_index:
+        # we shouldn't try to use it in the description.  maybe report this?
+        pass
+
+  # now we need to invert the map
+  aux_info = collections.defaultdict(set)
+  for key, index in target_key_to_info_index.iteritems():
+    aux_info[index].add(key)
+
+  return aux_info
+
+
+def _generate_content(
+    basedir, font, dir_infos, keys, aliases, excluded, annotations, standalone,
+    colors):
+  """Generate an html table for the infos.  Basedir is the parent directory of
+  the content, filenames will be made relative to this if underneath it, else
+  absolute. If font is not none, generate columns for the text rendered in the
+  font before other columns.  Dir_infos is the list of DirInfos in column
+  order.  Keys is the list of canonical emoji sequences in row order.  Aliases
+  and excluded indicate images we expect to not be present either because
+  they are aliased or specifically excluded.  If annotations is not none,
+  highlight sequences that appear in this map based on their map values ('ok',
+  'error', 'warning').  If standalone is true, the image data and font (if used)
+  will be copied under the basedir to make a completely stand-alone page.
+  Colors is the list of background colors, the last DirInfo column will be
+  repeated against each of these backgrounds.
+  """
+
+  basedir = path.abspath(path.expanduser(basedir))
+  if not path.isdir(basedir):
+    os.makedirs(basedir)
+
+  basepaths = []
+
+  if standalone:
+    # auxiliary images are used in the decomposition of multi-part emoji but
+    # aren't part of main set.  e.g. if we have female basketball player
+    # color-3 we want female, basketball player, and color-3 images available
+    # even if they aren't part of the target set.
+    aux_info = _collect_aux_info(dir_infos, keys)
+
+    # create image subdirectories in target dir, copy image files to them,
+    # and adjust paths
+    for i, info in enumerate(dir_infos):
+      subdir = '%02d' % i
+      dstdir = path.join(basedir, subdir)
+      if not path.isdir(dstdir):
+        os.mkdir(dstdir)
+
+      copy_keys = set(keys) | aux_info[i]
+      srcdir = info.directory
+      filemap = info.filemap
+      for key in copy_keys:
+        if key in filemap:
+          filename = filemap[key]
+          srcfile = path.join(srcdir, filename)
+          dstfile = path.join(dstdir, filename)
+          shutil.copy2(srcfile, dstfile)
+      basepaths.append(subdir)
+  else:
+    for srcdir, _, _ in dir_infos:
+      abs_srcdir = path.abspath(path.expanduser(srcdir))
+      if abs_srcdir == basedir:
+        dirspec = ''
+      elif abs_srcdir.startswith(basedir):
+        dirspec = abs_srcdir[len(basedir) + 1:]
+      else:
+        dirspec = abs_srcdir
+      basepaths.append(dirspec)
+
+  lines = ['<table>']
+  header_row = ['']
+  if font:
+    header_row.extend(['Emoji ltr', 'Emoji rtl'])
+  header_row.extend([info.title for info in dir_infos])
+  if len(colors) > 1:
+    header_row.extend([dir_infos[-1].title] * (len(colors) - 1))
+  header_row.extend(['Sequence', 'Name'])
+  lines.append('<th>'.join(header_row))
+
+  for key in keys:
+    row = _generate_row_cells(
+        key, font, aliases, excluded, dir_infos, basepaths, colors)
+    row.append(_get_desc(key, aliases, dir_infos, basepaths))
+    row.append(_get_name(key, annotations))
+    lines.append(''.join(row))
+
+  return '\n  <tr>'.join(lines) + '\n</table>'
+
+
+def _get_image_data(image_dir, ext, prefix):
+  """Return a map from a canonical tuple of cp sequences to a filename.
+
+  This filters by file extension, and expects the rest of the files
+  to match the prefix followed by a sequence of hex codepoints separated
+  by underscore.  Files that don't match, duplicate sequences (because
+  of casing), and out_of_range or empty codepoints raise an error."""
+
+  fails = []
+  result = {}
+  expect_re = re.compile(r'%s([0-9A-Fa-f_]+).%s' % (prefix, ext))
+  for f in sorted(glob.glob(path.join(image_dir, '*.%s' % ext))):
+    filename = path.basename(f)
+    m = expect_re.match(filename)
+    if not m:
+      if filename.startswith('unknown_flag.') or filename.startswith('p4p_'):
+        continue
+      fails.append('"%s" did not match: "%s"' % (expect_re.pattern, filename))
+      continue
+    seq = m.group(1)
+    this_failed = False
+    try:
+      cps = tuple(int(s, 16) for s in seq.split('_'))
+      for cp in cps:
+        if (cp > 0x10ffff):
+          fails.append('cp out of range: ' + filename)
+          this_failed = True
+          break
+      if this_failed:
+        continue
+      canonical_cps = unicode_data.get_canonical_emoji_sequence(cps)
+      if canonical_cps:
+        # if it is unrecognized, just leave it alone, else replace with
+        # canonical sequence.
+        cps = canonical_cps
+    except:
+      fails.append('bad cp sequence: ' + filename)
+      continue
+    if cps in result:
+      fails.append('duplicate sequence: %s and %s' (result[cps], filename))
+      continue
+    result[cps] = filename
+  if fails:
+    print('get_image_data failed (%s, %s, %s):\n  %s' % (
+        image_dir, ext, prefix, '\n  '.join(fails)), file=sys.stderr)
+    raise ValueError('get image data failed')
+  return result
+
+
+def _get_dir_infos(
+    image_dirs, exts=None, prefixes=None, titles=None,
+    default_ext=_default_ext, default_prefix=_default_prefix):
+  """Return a list of DirInfos for the image_dirs.  When defined,
+  exts, prefixes, and titles should be the same length as image_dirs.
+  Titles default to using the last segments of the image_dirs,
+  exts and prefixes default to the corresponding default values."""
+
+  count = len(image_dirs)
+  if not titles:
+    titles = [None] * count
+  elif len(titles) != count:
+      raise ValueError('have %d image dirs but %d titles' % (
+          count, len(titles)))
+  if not exts:
+    exts = [default_ext] * count
+  elif len(exts) != count:
+    raise ValueError('have %d image dirs but %d extensions' % (
+        count, len(exts)))
+  if not prefixes:
+    prefixes = [default_prefix] * count
+  elif len(prefixes) != count:
+    raise ValueError('have %d image dirs but %d prefixes' % (
+        count, len(prefixes)))
+
+  infos = []
+  for i in range(count):
+    image_dir = image_dirs[i]
+    title = titles[i] or path.basename(path.abspath(image_dir))
+    ext = exts[i] or default_ext
+    prefix = prefixes[i] or default_prefix
+    filemap = _get_image_data(image_dir, ext, prefix)
+    infos.append(DirInfo(image_dir, title, filemap))
+  return infos
+
+
+def _add_aliases(keys, aliases):
+  for k, v in sorted(aliases.iteritems()):
+    k_str = unicode_data.seq_to_string(k)
+    v_str = unicode_data.seq_to_string(v)
+    if k in keys:
+      msg = '' if v in keys else ' but it\'s not present'
+      print('have alias image %s, should use %s%s' % (k_str, v_str, msg))
+    elif v not in keys:
+      print('can\'t use alias %s, no image matching %s' % (k_str, v_str))
+  to_add = {k for k, v in aliases.iteritems() if k not in keys and v in keys}
+  return keys | to_add
+
+
+def _get_keys(dir_infos, aliases, limit, all_emoji, emoji_sort, ignore_missing):
+  """Return a list of the key tuples to display.  If all_emoji is
+  true, start with all emoji sequences, else the sequences available
+  in dir_infos (limited to the first dir_info if limit is True).
+  If ignore_missing is true and all_emoji is false, ignore sequences
+  that are not valid (e.g. skin tone variants of wrestlers).  If
+  ignore_missing is true and all_emoji is true, ignore sequences
+  for which we have no assets (e.g. newly defined emoji).  If not using
+  all_emoji, aliases are included if we have a target for them.
+  The result is in emoji order if emoji_sort is true, else in
+  unicode codepoint order."""
+
+  if all_emoji or ignore_missing:
+    all_keys = unicode_data.get_emoji_sequences()
+  if not all_emoji or ignore_missing:
+    if len(dir_infos) == 1 or limit:
+      avail_keys = frozenset(dir_infos[0].filemap.keys())
+    else:
+      avail_keys = _merge_keys([info.filemap for info in dir_infos])
+    if aliases:
+      avail_keys = _add_aliases(avail_keys, aliases)
+
+  if not ignore_missing:
+    keys = all_keys if all_emoji else avail_keys
+  else:
+    keys = set(all_keys) & avail_keys
+
+  if emoji_sort:
+    sorted_keys = unicode_data.get_sorted_emoji_sequences(keys)
+  else:
+    sorted_keys = sorted(keys)
+  return sorted_keys
+
+
+def _generate_info_text(args):
+  lines = ['%s: %r' % t for t in sorted(args.__dict__.iteritems())]
+  lines.append('generated by %s on %s' % (
+      path.basename(__file__), datetime.datetime.now()))
+  return '\n  '.join(lines)
+
+
+def _parse_annotation_file(afile):
+  """Parse file and return a map from sequences to one of 'ok', 'warning',
+  or 'error'.
+
+  The file format consists of two kinds of lines.  One defines the annotation
+  to apply, it consists of the text 'annotation:' followed by one of 'ok',
+  'warning', or 'error'.  The other defines a sequence that should get the most
+  recently defined annotation, this is a series of codepoints expressed in hex
+  separated by spaces.  The initial default annotation is 'error'.  '#' starts
+  a comment to end of line, blank lines are ignored.
+  """
+
+  annotations = {}
+  line_re = re.compile(r'annotation:\s*(ok|warning|error)|([0-9a-f ]+)')
+  annotation = 'error'
+  with open(afile, 'r') as f:
+    for line in f:
+      line = line.strip()
+      if not line or line[0] == '#':
+        continue
+      m = line_re.match(line)
+      if not m:
+        raise Exception('could not parse annotation "%s"' % line)
+      new_annotation = m.group(1)
+      if new_annotation:
+        annotation = new_annotation
+      else:
+        seq = tuple([int(s, 16) for s in m.group(2).split()])
+        canonical_seq = unicode_data.get_canonical_emoji_sequence(seq)
+        if canonical_seq:
+          seq = canonical_seq
+        if seq in annotations:
+          raise Exception(
+              'duplicate sequence %s in annotations' %
+              unicode_data.seq_to_string(seq))
+        annotations[seq] = annotation
+  return annotations
+
+
+def _instantiate_template(template, arg_dict):
+  id_regex = re.compile(r'\$([a-zA-Z0-9_]+)')
+  ids = set(m.group(1) for m in id_regex.finditer(template))
+  keyset = set(arg_dict.keys())
+  extra_args = keyset - ids
+  if extra_args:
+    print((
+        'the following %d args are unused:\n%s' %
+        (len(extra_args), ', '.join(sorted(extra_args)))), file=sys.stderr)
+  return string.Template(template).substitute(arg_dict)
+
+
+TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>$title</title>$fontFaceStyle
+    <style>$style</style>
+  </head>
+  <body>
+  <!--
+  $info
+  -->
+  <h3>$title</h3>
+  $content
+  </body>
+</html>
+"""
+
+STYLE = """
+      tbody { background-color: rgb(110, 110, 110) }
+      th { background-color: rgb(210, 210, 210) }
+      td img { width: 64px; height: 64px }
+      td:nth-last-of-type(2) {
+         font-size: 18pt; font-weight: regular; background-color: rgb(210, 210, 210)
+      }
+      td:nth-last-of-type(2) img {
+         vertical-align: bottom; width: 32px; height: 32px
+      }
+      td:last-of-type { background-color: white }
+      td.error { background-color: rgb(250, 65, 75) }
+      td.warning { background-color: rgb(240, 245, 50) }
+      td.ok { background-color: rgb(10, 200, 60) }
+"""
+
+def write_html_page(
+    filename, page_title, font, dir_infos, keys, aliases, excluded, annotations,
+    standalone, colors, info):
+
+  out_dir = path.dirname(filename)
+  if font:
+    if standalone:
+      # the assumption with standalone is that the source data and
+      # output directory don't overlap, this should probably be checked...
+
+      rel_fontpath = path.join('font', path.basename(font))
+      new_font = path.join(out_dir, rel_fontpath)
+      tool_utils.ensure_dir_exists(path.dirname(new_font))
+      shutil.copy2(font, new_font)
+      font = rel_fontpath
+    else:
+      common_prefix, (rel_dir, rel_font) = tool_utils.commonpathprefix(
+          [out_dir, font])
+      if rel_dir == '':
+        # font is in a subdirectory of the target, so just use the relative
+        # path
+        font = rel_font
+      else:
+        # use the absolute path
+        font = path.normpath(path.join(common_prefix, rel_font))
+
+  content = _generate_content(
+      path.dirname(filename), font, dir_infos, keys, aliases, excluded,
+      annotations, standalone, colors)
+  N_STYLE = STYLE
+  if font:
+    FONT_FACE_STYLE = """
+    <style>@font-face {
+      font-family: "Emoji"; src: local("Noto Color Emoji"), url("%s");
+    }</style>""" % font
+    N_STYLE += '      span.efont { font-family: "Emoji"; font-size:32pt }\n'
+  else:
+    FONT_FACE_STYLE = ''
+  num_final_cols = len(colors)
+  col_colors = ['']
+  for i, color in enumerate(colors):
+    col_colors.append(
+        """td:nth-last-of-type(%d) { background-color: #%s }\n""" % (
+            2 + num_final_cols - i, color))
+  N_STYLE += '       '.join(col_colors)
+  text = _instantiate_template(
+      TEMPLATE, {
+          'title': page_title, 'fontFaceStyle': FONT_FACE_STYLE,
+          'style': N_STYLE, 'content': content, 'info':info})
+  with codecs.open(filename, 'w', 'utf-8') as f:
+    f.write(text)
+
+
+def _get_canonical_aliases():
+  def canon(seq):
+    return unicode_data.get_canonical_emoji_sequence(seq) or seq
+  aliases = add_aliases.read_default_emoji_aliases()
+  return {canon(k): canon(v) for k, v in aliases.iteritems()}
+
+def _get_canonical_excluded():
+  def canon(seq):
+    return unicode_data.get_canonical_emoji_sequence(seq) or seq
+  aliases = add_aliases.read_default_unknown_flag_aliases()
+  return frozenset([canon(k) for k in aliases.keys()])
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '-o', '--outfile', help='path to output file', metavar='file',
+      required=True)
+  parser.add_argument(
+      '--page_title', help='page title', metavar='title', default='Emoji Table')
+  parser.add_argument(
+      '-d', '--image_dirs', help='image directories', metavar='dir',
+      nargs='+')
+  parser.add_argument(
+      '-e', '--exts', help='file extension, one per image dir', metavar='ext',
+      nargs='*')
+  parser.add_argument(
+      '-p', '--prefixes', help='file name prefix, one per image dir',
+      metavar='prefix', nargs='*')
+  parser.add_argument(
+      '-t', '--titles', help='title, one per image dir', metavar='title',
+      nargs='*'),
+  parser.add_argument(
+      '-l', '--limit', help='limit to only sequences supported by first set',
+      action='store_true')
+  parser.add_argument(
+      '-de', '--default_ext', help='default extension', metavar='ext',
+      default=_default_ext)
+  parser.add_argument(
+      '-dp', '--default_prefix', help='default prefix', metavar='prefix',
+      default=_default_prefix)
+  parser.add_argument(
+      '-f', '--font', help='emoji font', metavar='font')
+  parser.add_argument(
+      '-a', '--annotate', help='file listing sequences to annotate',
+      metavar='file')
+  parser.add_argument(
+      '-s', '--standalone', help='copy resources used by html under target dir',
+      action='store_true')
+  parser.add_argument(
+      '-c', '--colors', help='list of colors for background', nargs='*',
+      metavar='hex')
+  parser.add_argument(
+      '--all_emoji', help='use all emoji sequences', action='store_true')
+  parser.add_argument(
+      '--emoji_sort', help='use emoji sort order', action='store_true')
+  parser.add_argument(
+      '--ignore_missing', help='do not include missing emoji',
+      action='store_true')
+
+  args = parser.parse_args()
+  file_parts = path.splitext(args.outfile)
+  if file_parts[1] != '.html':
+    args.outfile = file_parts[0] + '.html'
+    print('added .html extension to filename:\n%s' % args.outfile)
+
+  if args.annotate:
+    annotations = _parse_annotation_file(args.annotate)
+  else:
+    annotations = None
+
+  if args.colors == None:
+    args.colors = ['6e6e6e']
+  elif not args.colors:
+    args.colors = """eceff1 f5f5f5 e4e7e9 d9dbdd 080808 263238 21272b 3c474c
+    4db6ac 80cbc4 5e35b1""".split()
+
+  dir_infos = _get_dir_infos(
+      args.image_dirs, args.exts, args.prefixes, args.titles,
+      args.default_ext, args.default_prefix)
+
+  aliases = _get_canonical_aliases()
+  keys = _get_keys(
+      dir_infos, aliases, args.limit, args.all_emoji, args.emoji_sort,
+      args.ignore_missing)
+
+  excluded = _get_canonical_excluded()
+
+  info = _generate_info_text(args)
+
+  write_html_page(
+      args.outfile, args.page_title, args.font, dir_infos, keys, aliases,
+      excluded, annotations, args.standalone, args.colors, info)
+
+
+if __name__ == "__main__":
+  main()

--- a/linux/generate_emoji_name_data.py
+++ b/linux/generate_emoji_name_data.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-#
+#
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate name data for emoji resources. Currently in json format."""
+from __future__ import print_function
+
+import argparse
+import collections
+import glob
+import json
+import os
+from os import path
+import re
+import sys
+
+import generate_emoji_html
+
+from nototools import tool_utils
+from nototools import unicode_data
+
+def _create_custom_gendered_seq_names():
+  """The names have detail that is adequately represented by the image."""
+
+  BOY = 0x1f466
+  GIRL = 0x1f467
+  MAN = 0x1f468
+  WOMAN = 0x1f469
+  HEART = 0x2764  # Heavy Black Heart
+  KISS_MARK = 0x1f48b
+  return {
+      (MAN, HEART, KISS_MARK, MAN): 'Kiss',
+      (WOMAN, HEART, KISS_MARK, WOMAN): 'Kiss',
+      (WOMAN, HEART, KISS_MARK, MAN): 'Kiss',
+      (WOMAN, HEART, MAN): 'Couple with Heart',
+      (MAN, HEART, MAN): 'Couple with Heart',
+      (WOMAN, HEART, WOMAN): 'Couple with Heart',
+      (MAN, GIRL): 'Family',
+      (MAN, GIRL, GIRL): 'Family',
+      (MAN, GIRL, BOY): 'Family',
+      (MAN, BOY): 'Family',
+      (MAN, BOY, BOY): 'Family',
+      (MAN, WOMAN, GIRL): 'Family',
+      (MAN, WOMAN, GIRL, GIRL): 'Family',
+      (MAN, WOMAN, GIRL, BOY): 'Family',
+      (MAN, WOMAN, BOY): 'Family',
+      (MAN, WOMAN, BOY, BOY): 'Family',
+      (MAN, MAN, GIRL): 'Family',
+      (MAN, MAN, GIRL, GIRL): 'Family',
+      (MAN, MAN, GIRL, BOY): 'Family',
+      (MAN, MAN, BOY): 'Family',
+      (MAN, MAN, BOY, BOY): 'Family',
+      (WOMAN, GIRL): 'Family',
+      (WOMAN, GIRL, GIRL): 'Family',
+      (WOMAN, GIRL, BOY): 'Family',
+      (WOMAN, BOY): 'Family',
+      (WOMAN, BOY, BOY): 'Family',
+      (WOMAN, WOMAN, GIRL): 'Family',
+      (WOMAN, WOMAN, GIRL, GIRL): 'Family',
+      (WOMAN, WOMAN, GIRL, BOY): 'Family',
+      (WOMAN, WOMAN, BOY): 'Family',
+      (WOMAN, WOMAN, BOY, BOY): 'Family' }
+
+def _create_custom_seq_names():
+  """These have names that often are of the form 'Person xyz-ing' or 'Man Xyz.'
+  We opt to simplify the former to an activity name or action, and the latter to
+  drop the gender.  This also generally makes the names shorter."""
+
+  EYE = 0x1f441
+  SPEECH = 0x1f5e8
+  WHITE_FLAG = 0x1f3f3
+  RAINBOW = 0x1f308
+  return {
+      (EYE, SPEECH): 'I Witness',
+      (WHITE_FLAG, RAINBOW): 'Rainbow Flag',
+      (0x2695,): 'Health Worker',
+      (0x2696,): 'Judge',
+      (0x26f7,): 'Skiing',
+      (0x26f9,): 'Bouncing a Ball',
+      (0x2708,): 'Pilot',
+      (0x1f33e,): 'Farmer',
+      (0x1f373,): 'Cook',
+      (0x1f393,): 'Student',
+      (0x1f3a4,): 'Singer',
+      (0x1f3a8,): 'Artist',
+      (0x1f3c2,): 'Snowboarding',
+      (0x1f3c3,): 'Running',
+      (0x1f3c4,): 'Surfing',
+      (0x1f3ca,): 'Swimming',
+      (0x1f3cb,): 'Weight Lifting',
+      (0x1f3cc,): 'Golfing',
+      (0x1f3eb,): 'Teacher',
+      (0x1f3ed,): 'Factory Worker',
+      (0x1f46e,): 'Police Officer',
+      (0x1f46f,): 'Partying',
+      (0x1f471,): 'Person with Blond Hair',
+      (0x1f473,): 'Person Wearing Turban',
+      (0x1f477,): 'Construction Worker',
+      (0x1f481,): 'Tipping Hand',
+      (0x1f482,): 'Guard',
+      (0x1f486,): 'Face Massage',
+      (0x1f487,): 'Haircut',
+      (0x1f4bb,): 'Technologist',
+      (0x1f4bc,): 'Office Worker',
+      (0x1f527,): 'Mechanic',
+      (0x1f52c,): 'Scientist',
+      (0x1f575,): 'Detective',
+      (0x1f645,): 'No Good Gesture',
+      (0x1f646,): 'OK Gesture',
+      (0x1f647,): 'Bowing Deeply',
+      (0x1f64b,): 'Raising Hand',
+      (0x1f64d,): 'Frowning',
+      (0x1f64e,): 'Pouting',
+      (0x1f680,): 'Astronaut',
+      (0x1f692,): 'Firefighter',
+      (0x1f6a3,): 'Rowing',
+      (0x1f6b4,): 'Bicycling',
+      (0x1f6b5,): 'Mountain Biking',
+      (0x1f6b6,): 'Walking',
+      (0x1f926,): 'Face Palm',
+      (0x1f937,): 'Shrug',
+      (0x1f938,): 'Doing a Cartwheel',
+      (0x1f939,): 'Juggling',
+      (0x1f93c,): 'Wrestling',
+      (0x1f93d,): 'Water Polo',
+      (0x1f93e,): 'Playing Handball',
+      (0x1f9d6,): 'Person in Steamy Room',
+      (0x1f9d7,): 'Climbing',
+      (0x1f9d8,): 'Person in Lotus Position',
+      (0x1f9d9,): 'Mage',
+      (0x1f9da,): 'Fairy',
+      (0x1f9db,): 'Vampire',
+      (0x1f9dd,): 'Elf',
+      (0x1f9de,): 'Genie',
+      (0x1f9df,): 'Zombie',
+  }
+
+_CUSTOM_GENDERED_SEQ_NAMES = _create_custom_gendered_seq_names()
+_CUSTOM_SEQ_NAMES = _create_custom_seq_names()
+
+# Fixes for unusual capitalization or cases we don't care to handle in code.
+# Also prevents titlecasing 'S' after apostrophe in posessives.  Note we _do_
+# want titlecasing after apostrophe in some cases, e.g. O'Clock.
+_CUSTOM_CAPS_NAMES = {
+    (0x26d1,): 'Rescue Worker’s Helmet',
+    (0x1f170,): 'A Button (blood type)',  # a Button (Blood Type)
+    (0x1f171,): 'B Button (blood type)',  # B Button (Blood Type)
+    (0x1f17e,): 'O Button (blood type)',  # O Button (Blood Type)
+    (0x1f18e,): 'AB Button (blood type)',  # Ab Button (Blood Type)
+    (0x1f191,): 'CL Button',  # Cl Button
+    (0x1f192,): 'COOL Button',  # Cool Button
+    (0x1f193,): 'FREE Button',  # Free Button
+    (0x1f194,): 'ID Button',  # Id Button
+    (0x1f195,): 'NEW Button',  # New Button
+    (0x1f196,): 'NG Button',  # Ng Button
+    (0x1f197,): 'OK Button',  # Ok Button
+    (0x1f198,): 'SOS Button',  # Sos Button
+    (0x1f199,): 'UP! Button',  # Up! Button
+    (0x1f19a,): 'VS Button',  # Vs Button
+    (0x1f3e7,): 'ATM Sign',  # Atm Sign
+    (0x1f44C,): 'OK Hand',  # Ok Hand
+    (0x1f452,): 'Woman’s Hat',
+    (0x1f45a,): 'Woman’s Clothes',
+    (0x1f45e,): 'Man’s Shoe',
+    (0x1f461,): 'Woman’s Sandal',
+    (0x1f462,): 'Woman’s Boot',
+    (0x1f519,): 'BACK Arrow',  # Back Arrow
+    (0x1f51a,): 'END Arrow',  # End Arrow
+    (0x1f51b,): 'ON! Arrow',  # On! Arrow
+    (0x1f51c,): 'SOON Arrow',  # Soon Arrow
+    (0x1f51d,): 'TOP Arrow',  # Top Arrow
+    (0x1f6b9,): 'Men’s Room',
+    (0x1f6ba,): 'Women’s Room',
+}
+
+# For the custom sequences we ignore ZWJ, the emoji variation selector
+# and skin tone modifiers.  We can't always ignore gender  because
+# the gendered sequences match against them, but we ignore gender in other
+# cases so we define a separate set of gendered emoji to remove.
+
+_NON_GENDER_CPS_TO_STRIP = frozenset(
+    [0xfe0f, 0x200d] +
+    range(unicode_data._FITZ_START, unicode_data._FITZ_END + 1))
+
+_GENDER_CPS_TO_STRIP = frozenset([0x2640, 0x2642, 0x1f468, 0x1f469])
+
+def _custom_name(seq):
+  """Apply three kinds of custom names, based on the sequence."""
+
+  seq = tuple([cp for cp in seq if cp not in _NON_GENDER_CPS_TO_STRIP])
+  name = _CUSTOM_CAPS_NAMES.get(seq)
+  if name:
+    return name
+
+  # Single characters that participate in sequences (e.g. fire truck in the
+  # firefighter sequences) should not get converted.  Single characters
+  # are in the custom caps names set but not the other sets.
+  if len(seq) == 1:
+    return None
+
+  name = _CUSTOM_GENDERED_SEQ_NAMES.get(seq)
+  if name:
+    return name
+
+  seq = tuple([cp for cp in seq if cp not in _GENDER_CPS_TO_STRIP])
+  name = _CUSTOM_SEQ_NAMES.get(seq)
+
+  return name
+
+
+def _standard_name(seq):
+  """Use the standard emoji name, with some algorithmic modifications.
+
+  We want to ignore skin-tone modifiers (but of course if the sequence _is_
+  the skin-tone modifier itself we keep that).  So we strip these so we can
+  start with the generic name ignoring skin tone.
+
+  Non-emoji that are turned into emoji using the emoji VS have '(emoji) '
+  prepended to them, so strip that.
+
+  Regional indicator symbol names are a bit long, so shorten them.
+
+  Regional sequences are assumed to be ok as-is in terms of capitalization and
+  punctuation, so no modifications are applied to them.
+
+  After title-casing we make some English articles/prepositions lower-case
+  again.  We also replace '&' with 'and'; Unicode seems rather fond of
+  ampersand."""
+
+  if not unicode_data.is_skintone_modifier(seq[0]):
+    seq = tuple([cp for cp in seq if not unicode_data.is_skintone_modifier(cp)])
+  name = unicode_data.get_emoji_sequence_name(seq)
+
+  if name.startswith('(emoji) '):
+    name = name[8:]
+
+  if len(seq) == 1 and unicode_data.is_regional_indicator(seq[0]):
+    return 'Regional Symbol ' + unicode_data.regional_indicator_to_ascii(seq[0])
+
+  if (unicode_data.is_regional_indicator_seq(seq) or
+      unicode_data.is_regional_tag_seq(seq)):
+    return name
+
+  name = name.title()
+  # Require space delimiting just in case...
+  name = re.sub(r'\s&\s', ' and ', name)
+  name = re.sub(
+      # not \b at start because we retain capital at start of phrase
+      r'(\s(:?A|And|From|In|Of|With|For))\b', lambda s: s.group(1).lower(),
+      name)
+
+  return name
+
+
+def _name_data(seq, seq_file):
+  name = _custom_name(seq) or _standard_name(seq)
+  # we don't need canonical sequences
+  sequence = ''.join('&#x%x;' % cp for cp in seq if cp != 0xfe0f)
+  fname = path.basename(seq_file)
+  return fname, sequence, name
+
+
+def generate_names(
+    src_dir, dst_dir, skip_limit=20, omit_groups=None, pretty_print=False,
+    verbose=False):
+  srcdir = tool_utils.resolve_path(src_dir)
+  if not path.isdir(srcdir):
+    print('%s is not a directory' % src_dir, file=sys.stderr)
+    return
+
+  if omit_groups:
+    unknown_groups = set(omit_groups) - set(unicode_data.get_emoji_groups())
+    if unknown_groups:
+      print('did not recognize %d group%s: %s' % (
+          len(unknown_groups), '' if len(unknown_groups) == 1 else 's',
+          ', '.join('"%s"' % g for g in omit_groups if g in unknown_groups)), file=sys.stderr)
+      print('valid groups are:\n  %s' % (
+          '\n  '.join(g for g in unicode_data.get_emoji_groups())), file=sys.stderr)
+      return
+    print('omitting %d group%s: %s' % (
+        len(omit_groups), '' if len(omit_groups) == 1 else 's',
+        ', '.join('"%s"' % g for g in omit_groups)))
+  else:
+    # might be None
+    print('keeping all groups')
+    omit_groups = []
+
+  # make sure the destination exists
+  dstdir = tool_utils.ensure_dir_exists(
+      tool_utils.resolve_path(dst_dir))
+
+  # _get_image_data returns canonical cp sequences
+  print('src dir:', srcdir)
+  seq_to_file = generate_emoji_html._get_image_data(srcdir, 'png', 'emoji_u')
+  print('seq to file has %d sequences' % len(seq_to_file))
+
+  # Aliases add non-gendered versions using gendered images for the most part.
+  # But when we display the images, we don't distinguish genders in the
+  # naming, we rely on the images-- so these look redundant. So we
+  # intentionally don't generate images for these.
+  # However, the alias file also includes the flag aliases, which we do want,
+  # and it also fails to exclude the unknown flag pua (since it doesn't
+  # map to anything), so we need to adjust for this.
+  canonical_aliases = generate_emoji_html._get_canonical_aliases()
+
+  aliases = set([
+      cps for cps in canonical_aliases.keys()
+      if not unicode_data.is_regional_indicator_seq(cps)])
+  aliases.add((0xfe82b,))  # unknown flag PUA
+  excluded = aliases | generate_emoji_html._get_canonical_excluded()
+
+  # The flag aliases have distinct names, so we _do_ want to show them
+  # multiple times.
+  to_add = {}
+  for seq in canonical_aliases:
+    if unicode_data.is_regional_indicator_seq(seq):
+      replace_seq = canonical_aliases[seq]
+      if seq in seq_to_file:
+        print('warning, alias %s has file %s' % (
+            unicode_data.regional_indicator_seq_to_string(seq),
+            seq_to_file[seq]))
+        continue
+      replace_file = seq_to_file.get(replace_seq)
+      if replace_file:
+        to_add[seq] = replace_file
+  seq_to_file.update(to_add)
+
+  data = []
+  last_skipped_group = None
+  skipcount = 0
+  for group in unicode_data.get_emoji_groups():
+    if group in omit_groups:
+      continue
+    name_data = []
+    for seq in unicode_data.get_emoji_in_group(group):
+      if seq in excluded:
+        continue
+      seq_file = seq_to_file.get(seq, None)
+      if seq_file is None:
+        skipcount += 1
+        if verbose:
+          if group != last_skipped_group:
+            print('group %s' % group)
+            last_skipped_group = group
+          print('  %s (%s)' % (
+              unicode_data.seq_to_string(seq),
+              ', '.join(unicode_data.name(cp, 'x') for cp in seq)))
+        if skip_limit >= 0 and skipcount > skip_limit:
+          raise Exception('skipped too many items')
+      else:
+        name_data.append(_name_data(seq, seq_file))
+    data.append({'category': group, 'emojis': name_data})
+
+  outfile = path.join(dstdir, 'data.json')
+  with open(outfile, 'w') as f:
+    indent = 2 if pretty_print else None
+    separators = None if pretty_print else (',', ':')
+    json.dump(data, f, indent=indent, separators=separators)
+  print('wrote %s' % outfile)
+
+
+def main():
+  DEFAULT_DSTDIR = '[emoji]/emoji'
+  DEFAULT_IMAGEDIR = '[emoji]/build/compressed_pngs'
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '-s', '--srcdir', help='directory containing images (default %s)' %
+      DEFAULT_IMAGEDIR,  metavar='dir', default=DEFAULT_IMAGEDIR)
+  parser.add_argument(
+      '-d', '--dstdir', help='name of destination directory (default %s)' %
+      DEFAULT_DSTDIR, metavar='fname', default=DEFAULT_DSTDIR)
+  parser.add_argument(
+      '-p', '--pretty_print', help='pretty-print json file',
+      action='store_true')
+  parser.add_argument(
+      '-m', '--missing_limit', help='number of missing images before failure '
+      '(default 20), use -1 for no limit', metavar='n', default=20)
+  parser.add_argument(
+      '--omit_groups', help='names of groups to omit (default "Misc")',
+      metavar='name', default=['Misc'], nargs='*')
+  parser.add_argument(
+      '-v', '--verbose', help='print progress information to stdout',
+      action='store_true')
+  args = parser.parse_args()
+  generate_names(
+      args.srcdir, args.dstdir, args.missing_limit, args.omit_groups,
+      pretty_print=args.pretty_print, verbose=args.verbose)
+
+
+if __name__ == "__main__":
+    main()

--- a/linux/generate_emoji_placeholders.py
+++ b/linux/generate_emoji_placeholders.py
@@ -1,0 +1,96 @@
+from __future__ import print_function
+import os
+from os import path
+import subprocess
+
+OUTPUT_DIR = '/tmp/placeholder_emoji'
+
+def generate_image(name, text):
+  print(name, text.replace('\n', '_'))
+  subprocess.check_call(
+      ['convert', '-size', '100x100', 'label:%s' % text,
+       '%s/%s' % (OUTPUT_DIR, name)])
+
+def is_color_patch(cp):
+  return cp >= 0x1f3fb and cp <= 0x1f3ff
+
+def has_color_patch(values):
+  for v in values:
+    if is_color_patch(v):
+      return True
+  return False
+
+def regional_to_ascii(cp):
+  return unichr(ord('A') + cp - 0x1f1e6)
+
+def is_flag_sequence(values):
+  if len(values) != 2:
+    return False
+  for v in values:
+    v -= 0x1f1e6
+    if v < 0 or v > 25:
+      return False
+  return True
+
+def is_keycap_sequence(values):
+  return len(values) == 2 and values[1] == 0x20e3
+
+def get_keycap_text(values):
+  return '-%c-' % unichr(values[0]) # convert gags on '['
+
+char_map = {
+    0x1f468: 'M',
+    0x1f469: 'W',
+    0x1f466: 'B',
+    0x1f467: 'G',
+    0x2764: 'H', # heavy black heart, no var sel
+    0x1f48b: 'K', # kiss mark
+    0x200D: '-', # zwj placeholder
+    0xfe0f: '-', # variation selector placeholder
+    0x1f441: 'I', # Eye
+    0x1f5e8: 'W', # 'witness' (left speech bubble)
+}
+
+def get_combining_text(values):
+  chars = []
+  for v in values:
+    char = char_map.get(v, None)
+    if not char:
+      return None
+    if char != '-':
+      chars.append(char)
+  return ''.join(chars)
+
+
+if not path.isdir(OUTPUT_DIR):
+  os.makedirs(OUTPUT_DIR)
+
+with open('sequences.txt', 'r') as f:
+  for seq in f:
+    seq = seq.strip()
+    text = None
+    values = [int(code, 16) for code in seq.split('_')]
+    if len(values) == 1:
+      val = values[0]
+      text = '%04X' % val # ensure upper case format
+    elif is_flag_sequence(values):
+      text = ''.join(regional_to_ascii(cp) for cp in values)
+    elif has_color_patch(values):
+      print('skipping color patch sequence %s' % seq)
+    elif is_keycap_sequence(values):
+      text = get_keycap_text(values)
+    else:
+      text = get_combining_text(values)
+      if not text:
+        print('missing %s' % seq)
+
+    if text:
+      if len(text) > 3:
+        if len(text) == 4:
+          hi = text[:2]
+          lo = text[2:]
+        else:
+          hi = text[:-3]
+          lo = text[-3:]
+        text = '%s\n%s' % (hi, lo)
+      generate_image('emoji_u%s.png' % seq, text)

--- a/linux/generate_emoji_thumbnails.py
+++ b/linux/generate_emoji_thumbnails.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate 72x72 thumbnails including aliases.
+
+Takes a source directory of images named using our emoji filename
+conventions and writes thumbnails of them into the destination
+directory.  If a file is a target of one or more aliases, creates
+copies named for the aliases."""
+
+
+import argparse
+import collections
+import logging
+import os
+from os import path
+import shutil
+import subprocess
+
+import add_aliases
+
+from nototools import tool_utils
+from nototools import unicode_data
+
+logger = logging.getLogger('emoji_thumbnails')
+
+def create_thumbnail(src_path, dst_path, crop):
+  # Uses imagemagik
+  # We need images exactly 72x72 in size, with transparent background.
+  # Remove 4-pixel LR margins from 136x128 source images if we crop.
+  if crop:
+    cmd = [
+        'convert', src_path, '-crop', '128x128+4+0!', '-thumbnail', '72x72',
+        'PNG32:' + dst_path]
+  else:
+    cmd = [
+        'convert', '-thumbnail', '72x72', '-gravity', 'center', '-background',
+        'none', '-extent', '72x72', src_path, 'PNG32:' + dst_path]
+  subprocess.check_call(cmd)
+
+
+def get_inv_aliases():
+  """Return a mapping from target to list of sources for all alias
+  targets in either the default alias table or the unknown_flag alias
+  table."""
+
+  inv_aliases = collections.defaultdict(list)
+
+  standard_aliases = add_aliases.read_default_emoji_aliases()
+  for k, v in standard_aliases.iteritems():
+    inv_aliases[v].append(k)
+
+  unknown_flag_aliases = add_aliases.read_emoji_aliases(
+      'unknown_flag_aliases.txt')
+  for k, v in unknown_flag_aliases.iteritems():
+    inv_aliases[v].append(k)
+
+  return inv_aliases
+
+
+def filename_to_sequence(filename, prefix, suffix):
+  if not filename.startswith(prefix) and filename.endswith(suffix):
+    raise ValueError('bad prefix or suffix: "%s"' % filename)
+  seq_str = filename[len(prefix): -len(suffix)]
+  seq = unicode_data.string_to_seq(seq_str)
+  if not unicode_data.is_cp_seq(seq):
+    raise ValueError('sequence includes non-codepoint: "%s"' % filename)
+  return seq
+
+
+def sequence_to_filename(seq, prefix, suffix):
+  return ''.join((prefix, unicode_data.seq_to_string(seq), suffix))
+
+
+def create_thumbnails_and_aliases(src_dir, dst_dir, crop, dst_prefix):
+  """Creates thumbnails in dst_dir based on sources in src.dir, using
+  dst_prefix. Assumes the source prefix is 'emoji_u' and the common suffix
+  is '.png'."""
+
+  src_dir = tool_utils.resolve_path(src_dir)
+  if not path.isdir(src_dir):
+    raise ValueError('"%s" is not a directory')
+
+  dst_dir = tool_utils.ensure_dir_exists(tool_utils.resolve_path(dst_dir))
+
+  src_prefix = 'emoji_u'
+  suffix = '.png'
+
+  inv_aliases = get_inv_aliases()
+
+  for src_file in os.listdir(src_dir):
+    try:
+      seq = unicode_data.strip_emoji_vs(
+          filename_to_sequence(src_file, src_prefix, suffix))
+    except ValueError as ve:
+      logger.warning('Error (%s), skipping' % ve)
+      continue
+
+    src_path = path.join(src_dir, src_file)
+
+    dst_file = sequence_to_filename(seq, dst_prefix, suffix)
+    dst_path = path.join(dst_dir, dst_file)
+
+    create_thumbnail(src_path, dst_path, crop)
+    logger.info('wrote thumbnail%s: %s' % (
+        ' with crop' if crop else '', dst_file))
+
+    for alias_seq in inv_aliases.get(seq, ()):
+      alias_file = sequence_to_filename(alias_seq, dst_prefix, suffix)
+      alias_path = path.join(dst_dir, alias_file)
+      shutil.copy2(dst_path, alias_path)
+      logger.info('wrote alias: %s' % alias_file)
+
+
+def main():
+  SRC_DEFAULT = '[emoji]/build/compressed_pngs'
+  PREFIX_DEFAULT = 'android_'
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '-s', '--src_dir', help='source images (default \'%s\')' % SRC_DEFAULT,
+      default=SRC_DEFAULT, metavar='dir')
+  parser.add_argument(
+      '-d', '--dst_dir', help='destination directory', metavar='dir',
+      required=True)
+  parser.add_argument(
+      '-p', '--prefix', help='prefix for thumbnail (default \'%s\')' %
+      PREFIX_DEFAULT, default=PREFIX_DEFAULT, metavar='str')
+  parser.add_argument(
+      '-c', '--crop', help='crop images (will automatically crop if '
+      'src dir is the default)', action='store_true')
+  parser.add_argument(
+      '-v', '--verbose', help='write log output', metavar='level',
+      choices='warning info debug'.split(), const='info',
+      nargs='?')
+  args = parser.parse_args()
+
+  if args.verbose is not None:
+    logging.basicConfig(level=getattr(logging, args.verbose.upper()))
+
+  crop = args.crop or (args.src_dir == SRC_DEFAULT)
+  create_thumbnails_and_aliases(
+      args.src_dir, args.dst_dir, crop, args.prefix)
+
+
+if __name__ == '__main__':
+  main()

--- a/linux/generate_test_html.py
+++ b/linux/generate_test_html.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+# Copyright 2015 Google, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Google Author(s): Doug Felt
+
+from __future__ import print_function
+import argparse
+import os
+import os.path
+import re
+import sys
+
+from fontTools import ttx
+
+import add_svg_glyphs
+
+def do_generate_test_html(font_basename, pairs, glyph=None, verbosity=1):
+  header = r"""<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style type="text/css">
+@font-face { font-family: svgfont; src: url("%s") }
+body { font-family: sans-serif; font-size: 24px }
+#emoji span { font-family: svgfont, sans-serif }
+#panel { font-family: svgfont, sans-serif; font-size: 256px }
+#paneltitle { font-family: sans-serif; font-size: 36px }
+</style>
+<script type="text/javascript">
+function hexify(text) {
+  var surr_offset = 0x10000 - (0xd800 << 10) - 0xdc00
+  var str = text.trim()
+  var len = str.length
+  var result = ""
+  for (var i = 0; i < len; ++i) {
+    var cp = str.charCodeAt(i)
+    if (cp >= 0xd800 && cp < 0xdc00 && i < len - 1) {
+      ncp = str.charCodeAt(i+1)
+      if (ncp >= 0xdc00 && ncp < 0xe000) {
+        cp = (cp << 10) + ncp + surr_offset
+        ++i;
+      }
+    }
+    result += " 0x" + cp.toString(16)
+  }
+  return result
+};
+
+function showText(event) {
+  var text = event.target.textContent
+  var p = document.getElementById('panel')
+  p.textContent = text
+  p = document.getElementById('paneltitle')
+  p.textContent = hexify(text)
+};
+
+function setup() {
+  var t = document.getElementById('emoji')
+  var tdlist = t.getElementsByTagName('span')
+  for (var i = 0; i < tdlist.length; ++i) {
+    var e = tdlist[i]
+    e.onmouseover = showText
+  }
+};
+</script>
+</head>"""
+
+  body_head = r"""<body onload="setup();">
+<p>Test for SVG glyphs in %(font)s.  It uses the proposed
+<a href="http://lists.w3.org/Archives/Public/public-svgopentype/2013Jul/0003.html">SVG-in-OpenType format</a>.
+View using Firefox&nbsp;26 and later.
+<div style="float:left; text-align:center; margin:0 10px; width:40%%">
+<div id='panel' style="margin-left:auto; margin-right:auto">%(glyph)s</div>
+<div id='paneltitle' style="margin-left:auto; margin-right:auto">%(glyph_hex)s</div>
+</div>
+<div id='emoji'><p>"""
+
+  body_tail = r"""</div>
+</body>
+</html>
+"""
+
+  font_name = font_basename + ".woff"
+  html_name = font_basename + "_test.html"
+
+  found_initial_glyph = False
+  initial_glyph_str = None;
+  initial_glyph_hex = None;
+  text_parts = []
+  for glyphstr, _ in pairs:
+    name_parts = []
+    hex_parts = []
+    for cp in glyphstr:
+      hex_str = hex(ord(cp))
+      name_parts.append('&#x%s;' % hex_str[2:])
+      hex_parts.append(hex_str)
+    glyph_str = ''.join(name_parts)
+
+    if not found_initial_glyph:
+      if not glyph or glyph_str == glyph:
+        initial_glyph_str = glyph_str
+        initial_glyph_hex = ' '.join(hex_parts)
+        found_initial_glyph = True
+      elif not initial_glyph_str:
+        initial_glyph_str = glyph_str
+        initial_glyph_hex = ' '.join(hex_parts)
+
+    text = '<span>%s</span>' % glyph_str
+    text_parts.append(text)
+
+  if verbosity and glyph and not found_initial_glyph:
+    print("Did not find glyph '%s', using initial glyph '%s'" % (glyph, initial_glyph_str))
+  elif verbosity > 1 and not glyph:
+    print("Using initial glyph '%s'" % initial_glyph_str)
+
+  lines = [header % font_name]
+  lines.append(body_head % {'font':font_name, 'glyph':initial_glyph_str,
+                            'glyph_hex':initial_glyph_hex})
+  lines.extend(text_parts) # we'll end up with space between each emoji
+  lines.append(body_tail)
+  output = '\n'.join(lines)
+  with open(html_name, 'w') as fp:
+    fp.write(output)
+  if verbosity:
+    print('Wrote ' + html_name)
+
+
+def do_generate_fonts(template_file, font_basename, pairs, reuse=0, verbosity=1):
+  out_woff = font_basename + '.woff'
+  if reuse > 1 and os.path.isfile(out_woff) and os.access(out_woff, os.R_OK):
+    if verbosity:
+      print('Reusing ' + out_woff)
+    return
+
+  out_ttx = font_basename + '.ttx'
+  if reuse == 0:
+    add_svg_glyphs.add_image_glyphs(template_file, out_ttx, pairs, verbosity=verbosity)
+  elif verbosity:
+    print('Reusing ' + out_ttx)
+
+  quiet=verbosity < 2
+  font = ttx.TTFont(flavor='woff', quiet=quiet)
+  font.importXML(out_ttx, quiet=quiet)
+  font.save(out_woff)
+  if verbosity:
+    print('Wrote ' + out_woff)
+
+
+def main(argv):
+  usage = """This will search for files that have image_prefix followed by one or more
+      hex numbers (separated by underscore if more than one), and end in ".svg".
+      For example, if image_prefix is "icons/u", then files with names like
+      "icons/u1F4A9.svg" or "icons/u1F1EF_1F1F5.svg" will be found. It generates
+      an SVG font from this, converts it to woff, and also generates an html test
+      page containing text for all the SVG glyphs."""
+
+  parser = argparse.ArgumentParser(
+      description='Generate font and html test file.', epilog=usage)
+  parser.add_argument('template_file', help='name of template .ttx file')
+  parser.add_argument('image_prefix', help='location and prefix of image files')
+  parser.add_argument('-i', '--include', help='include files whoses name matches this regex')
+  parser.add_argument('-e', '--exclude', help='exclude files whose name matches this regex')
+  parser.add_argument('-o', '--out_basename', help='base name of (ttx, woff, html) files to generate, '
+                      'defaults to the template base name')
+  parser.add_argument('-g', '--glyph', help='set the initial glyph text (html encoded string), '
+                      'defaults to first glyph')
+  parser.add_argument('-rt', '--reuse_ttx_font', dest='reuse_font', help='use existing ttx font',
+                      default=0, const=1, action='store_const')
+  parser.add_argument('-r', '--reuse_font', dest='reuse_font', help='use existing woff font',
+                      const=2, action='store_const')
+  parser.add_argument('-q', '--quiet', dest='v', help='quiet operation', default=1,
+                      action='store_const', const=0)
+  parser.add_argument('-v', '--verbose', dest='v', help='verbose operation',
+                      action='store_const', const=2)
+  args = parser.parse_args(argv)
+
+  pairs = add_svg_glyphs.collect_glyphstr_file_pairs(
+    args.image_prefix, 'svg', include=args.include, exclude=args.exclude, verbosity=args.v)
+  add_svg_glyphs.sort_glyphstr_tuples(pairs)
+
+  out_basename = args.out_basename
+  if not out_basename:
+    out_basename = args.template_file.split('.')[0] # exclude e.g. '.tmpl.ttx'
+    if args.v:
+      print("Output basename is %s." % out_basename)
+  do_generate_fonts(args.template_file, out_basename, pairs, reuse=args.reuse_font, verbosity=args.v)
+  do_generate_test_html(out_basename, pairs, glyph=args.glyph, verbosity=args.v)
+
+if __name__ == '__main__':
+  main(sys.argv[1:])

--- a/linux/map_pua_emoji.py
+++ b/linux/map_pua_emoji.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Modify an emoji font to map legacy PUA characters to standard ligatures."""
+
+__author__ = 'roozbeh@google.com (Roozbeh Pournader)'
+
+import sys
+
+from fontTools import ttLib
+
+from nototools import font_data
+
+import add_emoji_gsub
+
+
+def get_glyph_name_from_gsub(char_seq, font):
+    """Find the glyph name for ligature of a given character sequence from GSUB.
+    """
+    cmap = font_data.get_cmap(font)
+    # FIXME: So many assumptions are made here.
+    try:
+        first_glyph = cmap[char_seq[0]]
+        rest_of_glyphs = [cmap[ch] for ch in char_seq[1:]]
+    except KeyError:
+        return None
+
+    for lookup in font['GSUB'].table.LookupList.Lookup:
+        ligatures = lookup.SubTable[0].ligatures
+        try:
+            for ligature in ligatures[first_glyph]:
+                if ligature.Component == rest_of_glyphs:
+                    return ligature.LigGlyph
+        except KeyError:
+            continue
+    return None
+
+
+def add_pua_cmap(source_file, target_file):
+    """Add PUA characters to the cmap of the first font and save as second."""
+    font = ttLib.TTFont(source_file)
+    cmap = font_data.get_cmap(font)
+    for pua, (ch1, ch2) in (add_emoji_gsub.EMOJI_KEYCAPS.items()
+                            + add_emoji_gsub.EMOJI_FLAGS.items()):
+        if pua not in cmap:
+            glyph_name = get_glyph_name_from_gsub([ch1, ch2], font)
+            if glyph_name is not None:
+                cmap[pua] = glyph_name
+    font.save(target_file)
+
+
+def main(argv):
+    """Save the first font given to the second font."""
+    add_pua_cmap(argv[1], argv[2])
+
+
+if __name__ == '__main__':
+    main(sys.argv)
+

--- a/linux/materialize_emoji_images.py
+++ b/linux/materialize_emoji_images.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Create a copy of the emoji images that instantiates aliases, etc. as
+symlinks."""
+from __future__ import print_function
+
+import argparse
+import glob
+import os
+from os import path
+import re
+import shutil
+
+from nototools import tool_utils
+
+# copied from third_party/color_emoji/add_glyphs.py
+
+EXTRA_SEQUENCES = {
+    'u1F46A': '1F468_200D_1F469_200D_1F466', # MWB
+    'u1F491': '1F469_200D_2764_FE0F_200D_1F468', # WHM
+    'u1F48F': '1F469_200D_2764_FE0F_200D_1F48B_200D_1F468', # WHKM
+}
+
+# Flag aliases - from: to
+FLAG_ALIASES = {
+    'BV': 'NO',
+    'CP': 'FR',
+    'HM': 'AU',
+    'SJ': 'NO',
+    'UM': 'US',
+}
+
+OMITTED_FLAGS = set(
+    'BL BQ DG EA EH FK GF GP GS MF MQ NC PM RE TF WF XK YT'.split())
+
+def _flag_str(ris_pair):
+  return '_'.join('%04x' % (ord(cp) - ord('A') +  0x1f1e6)
+                  for cp in ris_pair)
+
+def _copy_files(src, dst):
+  """Copies files named 'emoji_u*.png' from dst to src, and return a set of
+  the names with 'emoji_u' and the extension stripped."""
+  code_strings = set()
+  tool_utils.check_dir_exists(src)
+  dst = tool_utils.ensure_dir_exists(dst, clean=True)
+  for f in glob.glob(path.join(src, 'emoji_u*.png')):
+    shutil.copy(f, dst)
+    code_strings.add(path.splitext(path.basename(f))[0][7:])
+  return code_strings
+
+
+def _alias_people(code_strings, dst):
+  """Create aliases for people in dst, based on code_strings."""
+  for src, ali in sorted(EXTRA_SEQUENCES.items()):
+    if src[1:].lower() in code_strings:
+      src_name = 'emoji_%s.png' % src.lower()
+      ali_name = 'emoji_u%s.png' % ali.lower()
+      print('creating symlink %s -> %s' % (ali_name, src_name))
+      os.symlink(path.join(dst, src_name), path.join(dst, ali_name))
+    else:
+      print('people image %s not found' % src, file=os.stderr)
+
+
+def _alias_flags(code_strings, dst):
+  for ali, src in sorted(FLAG_ALIASES.items()):
+    src_str = _flag_str(src)
+    if src_str in code_strings:
+      src_name = 'emoji_u%s.png' % src_str
+      ali_name = 'emoji_u%s.png' % _flag_str(ali)
+      print('creating symlink %s (%s) -> %s (%s)' % (ali_name, ali, src_name, src))
+      os.symlink(path.join(dst, src_name), path.join(dst, ali_name))
+    else:
+      print('flag image %s (%s) not found' % (src_name, src), file=os.stderr)
+
+
+def _alias_omitted_flags(code_strings, dst):
+  UNKNOWN_FLAG = 'fe82b'
+  if UNKNOWN_FLAG not in code_strings:
+    print('unknown flag missing', file=os.stderr)
+    return
+  dst_name = 'emoji_u%s.png' % UNKNOWN_FLAG
+  dst_path = path.join(dst, dst_name)
+  for ali in sorted(OMITTED_FLAGS):
+    ali_str = _flag_str(ali)
+    if ali_str in code_strings:
+      print('omitted flag %s has image %s' % (ali, ali_str), file=os.stderr)
+      continue
+    ali_name = 'emoji_u%s.png' % ali_str
+    print('creating symlink %s (%s) -> unknown_flag (%s)' % (
+        ali_str, ali, dst_name))
+    os.symlink(dst_path, path.join(dst, ali_name))
+
+
+def materialize_images(src, dst):
+  code_strings = _copy_files(src, dst)
+  _alias_people(code_strings, dst)
+  _alias_flags(code_strings, dst)
+  _alias_omitted_flags(code_strings, dst)
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '-s', '--srcdir', help='path to input sources', metavar='dir',
+      default = 'build/compressed_pngs')
+  parser.add_argument(
+      '-d', '--dstdir', help='destination for output images', metavar='dir')
+  args = parser.parse_args()
+  materialize_images(args.srcdir, args.dstdir)
+
+
+if __name__ == '__main__':
+  main()

--- a/linux/strip_vs_from_filenames.py
+++ b/linux/strip_vs_from_filenames.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import argparse
+import glob
+import os
+from os import path
+import sys
+
+"""Rename image files based on codepoints to remove the emoji variation
+selector from the name.  For our emoji image data, this codepoint is not
+relevant."""
+
+EMOJI_VS = 0xfe0f
+
+
+def str_to_seq(seq_str):
+  return tuple([int(s, 16) for s in seq_str.split('_')])
+
+
+def seq_to_str(seq):
+  return '_'.join('%04x' % cp for cp in seq)
+
+
+def strip_vs(seq):
+  return tuple([cp for cp in seq if cp != EMOJI_VS])
+
+
+def strip_vs_from_filenames(imagedir, prefix, ext, dry_run=False):
+  prefix_len = len(prefix)
+  suffix_len = len(ext) + 1
+  names = [path.basename(f)
+           for f in glob.glob(
+               path.join(imagedir, '%s*.%s' % (prefix, ext)))]
+  renames = {}
+  for name in names:
+    seq = str_to_seq(name[prefix_len:-suffix_len])
+    if seq and EMOJI_VS in seq:
+      newname = '%s%s.%s' % (prefix, seq_to_str(strip_vs(seq)), ext)
+      if newname in names:
+        print('%s non-vs name %s already exists.' % (
+            name, newname), file=sys.stderr)
+        return
+      renames[name] = newname
+
+  for k, v in renames.iteritems():
+    if dry_run:
+      print('%s -> %s' % (k, v))
+    else:
+      os.rename(path.join(imagedir, k), path.join(imagedir, v))
+  print('renamed %d files in %s' % (len(renames), imagedir))
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '-d', '--imagedir', help='directory containing images to rename',
+      metavar='dir', required=True)
+  parser.add_argument(
+      '-e', '--ext', help='image filename extension (default png)',
+      choices=['ai', 'png', 'svg'], default='png')
+  parser.add_argument(
+      '-p', '--prefix', help='image filename prefix (default emoji_u)',
+      default='emoji_u', metavar='pfx')
+  parser.add_argument(
+      '-n', '--dry_run', help='compute renames and list only',
+      action='store_true')
+
+  args = parser.parse_args()
+  strip_vs_from_filenames(args.imagedir, args.prefix, args.ext, args.dry_run)
+
+
+if __name__ == '__main__':
+  main()

--- a/linux/svg_builder.py
+++ b/linux/svg_builder.py
@@ -1,0 +1,198 @@
+# Copyright 2015 Google, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Google Author(s): Doug Felt
+
+import math
+import random
+import re
+import string
+
+import svg_cleaner
+
+class SvgBuilder(object):
+  """Modifies a font to add SVG glyphs from a document or string.  Once built you
+  can call add_from_filename or add_from_doc multiple times to add SVG
+  documents, which should contain a single root svg element representing the glyph.
+  This element must have width and height attributes (in px), these are used to
+  determine how to scale the glyph.  The svg should be designed to fit inside
+  this bounds and have its origin at the top left.  Adding the svg generates a
+  transform to scale and position the glyph, so the svg element should not have
+  a transform attribute since it will be overwritten.  Any id attribute on the
+  glyph is also overwritten.
+
+  Adding a glyph can generate additional default glyphs for components of a
+  ligature that are not already present.
+
+  It is possible to add SVG images to a font that already has corresponding
+  glyphs.  If a glyph exists already, then its hmtx advance is assumed valid.
+  Otherwise we will generate an advance based on the image's width and scale
+  factor.  Callers should ensure that glyphs for components of ligatures are
+  added before the ligatures themselves, otherwise glyphs generated for missing
+  ligature components will be assigned zero metrics metrics that will not be
+  overridden later."""
+
+  def __init__(self, font_builder):
+    font_builder.init_svg()
+
+    self.font_builder = font_builder
+    self.cleaner = svg_cleaner.SvgCleaner()
+
+    font = font_builder.font
+    self.font_ascent = font['hhea'].ascent
+    self.font_height = self.font_ascent - font['hhea'].descent
+    self.font_upem = font['head'].unitsPerEm
+
+  def add_from_filename(self, ustr, filename):
+    with open(filename, "r") as fp:
+      return self.add_from_doc(ustr, fp.read(), filename=filename)
+
+  def _strip_px(self, val):
+    return float(val[:-2] if val.endswith('px') else val)
+
+  def add_from_doc(self, ustr, svgdoc, filename=None):
+    """Cleans the svg doc, tweaks the root svg element's
+    attributes, then updates the font.  ustr is the character or ligature
+    string, svgdoc is the svg document xml.  The doc must have a single
+    svg root element."""
+
+    # The svg element must have an id attribute of the form 'glyphNNN' where NNN
+    # is the glyph id.  We capture the index of the glyph we're adding and write
+    # it into the svg.
+    #
+    # We generate a transform that places the origin at the top left of the
+    # ascent and uniformly scales it to fit both the font height (ascent -
+    # descent) and glyph advance if it is already present.  The initial viewport
+    # is 1000x1000. When present, viewBox scales to fit this and uses default
+    # values for preserveAspectRatio that center the viewBox in this viewport
+    # ('xMidyMid meet'), and ignores the width and height.  If viewBox is not
+    # present, width and height cause a (possibly non-uniform) scale to be
+    # applied that map the extent to the viewport.  This is unfortunate for us,
+    # since we want to preserve the aspect ratio, and the image is likely
+    # designed for a viewport with the width and height it requested.
+    #
+    # If we have an advance, we want to replicate the behavior of viewBox,
+    # except using a 'viewport' of advance, ascent+descent. If we don't have
+    # an advance, we scale the height and compute the advance from the scaled
+    # width.
+    #
+    # Lengths using percentage units map 100% to the width/height/diagonal
+    # of the viewBox, or if it is not defined, the viewport.  Since we can't
+    # define the viewport, we must always have a viewBox.
+
+    cleaner = self.cleaner
+    fbuilder = self.font_builder
+
+    tree = cleaner.tree_from_text(svgdoc)
+
+    name, index, exists = fbuilder.add_components_and_ligature(ustr)
+
+    advance = 0
+    if exists:
+      advance = fbuilder.hmtx[name][0]
+
+    vb = tree.attrs.get('viewBox')
+    if vb:
+      x, y, w, h = map(self._strip_px, re.split('\s*,\s*|\s+', vb))
+    else:
+      wid = tree.attrs.get('width')
+      ht = tree.attrs.get('height')
+      if not (wid and ht):
+        raise ValueError(
+            'missing viewBox and width or height attrs (%s)' % filename)
+      x, y, w, h = 0, 0, self._strip_px(wid), self._strip_px(ht)
+
+    # We're going to assume default values for preserveAspectRatio for now,
+    # this preserves aspect ratio and centers in the viewport.
+    #
+    # The viewport is 0,0 1000x1000. First compute the scaled extent and
+    # translations that center the image rect in the viewport, then scale and
+    # translate the result to fit our true 'viewport', which has an origin at
+    # 0,-ascent and an extent of advance (if defined) x font_height.  We won't
+    # try to optimize this, it's clearer what we're doing this way.
+
+    # Since the viewport is square, we can just compare w and h to determine
+    # which to fit to the viewport extent.  Get our position and extent in
+    # the viewport.
+    if w > h:
+        scale_to_viewport = 1000.0 / w
+        h_in_viewport = scale_to_viewport * h
+        y_in_viewport = (1000 - h_in_viewport) / 2
+        w_in_viewport = 1000.0
+        x_in_viewport = 0.0
+    else:
+        scale_to_viewport = 1000.0 / h
+        h_in_viewport = 1000.0
+        y_in_viewport = 0.0
+        w_in_viewport = scale_to_viewport * w
+        x_in_viewport = (1000 - w_in_viewport) / 2
+
+    # Now, compute the scale and translations that fit this rectangle to our
+    # true 'viewport'.  The true viewport is not square so we need to choose the
+    # smaller of the scales that fit its height or width.  We start with height,
+    # if there's no advance then we're done, otherwise we might have to fit the
+    # advance.
+    scale = self.font_height / h_in_viewport
+    fit_height = True
+    if advance and scale * w_in_viewport > advance:
+      scale = advance / w_in_viewport
+      fit_height = False
+
+    # Compute transforms that put the top left of the image where we want it.
+    ty = -self.font_ascent - scale * y_in_viewport
+    tx = -scale * x_in_viewport
+
+    # Adjust them to center the image horizontally if we fit the full height,
+    # vertically otherwise.
+    if fit_height and advance:
+      tx += (advance - scale * w_in_viewport) / 2
+    else:
+      ty += (self.font_height - scale * h_in_viewport) / 2
+
+    cleaner.clean_tree(tree)
+
+    tree.attrs['id'] = 'glyph%s' % index
+
+    transform = 'translate(%g, %g) scale(%g)' % (tx, ty, scale)
+    tree.attrs['transform'] = transform
+
+    tree.attrs['viewBox'] = '%g %g %g %g' % (x, y, w, h)
+
+    # In order to clip, we need to create a path and reference it.  You'd think
+    # establishing a rectangular clip would be simpler...  Aaaaand... as it
+    # turns out, in FF the clip on the outer svg element is only relative to the
+    # initial viewport, and is not affected by the viewBox or transform on the
+    # svg element.  Unlike chrome.  So either we apply an inverse transform, or
+    # insert a group with the clip between the svg and its children.  The latter
+    # seems cleaner, ultimately.
+    clip_id = 'clip_' + ''.join(
+        random.choice(string.ascii_lowercase) for i in range(8))
+    clip_text = ('<g clip-path="url(#%s)"><clipPath id="%s">'
+      '<path d="M%g %gh%gv%gh%gz"/></clipPath></g>' % (
+          clip_id, clip_id, x, y, w, h, -w))
+    clip_tree = cleaner.tree_from_text(clip_text)
+    clip_tree.contents.extend(tree.contents)
+    tree.contents = [clip_tree]
+
+    svgdoc = cleaner.tree_to_text(tree)
+
+    hmetrics = None
+    if not exists:
+      # There was no advance to fit, so no horizontal centering. The image advance is
+      # all there is.
+      # hmetrics is horiz advance and lsb
+      advance = scale * w_in_viewport
+      hmetrics = [int(round(advance)), 0]
+
+    fbuilder.add_svg(svgdoc, hmetrics, name, index)

--- a/linux/svg_cleaner.py
+++ b/linux/svg_cleaner.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python
+# Copyright 2015 Google, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Google Author(s): Doug Felt
+
+"""Clean SVG.
+
+svgo could do this, but we're fussy.  Also, emacs doesn't understand
+that 'style' defaults to 'text/css' and svgo strips this out by
+default.
+
+The files we're getting that are exported from AI contain lots of extra
+data so that it can reimport the svg, and we don't need it."""
+
+
+import argparse
+import codecs
+import logging
+import os
+from os import path
+import re
+import sys
+
+from nototools import tool_utils
+
+from xml.parsers import expat
+from xml.sax import saxutils
+
+# Expat doesn't allow me to identify empty tags (in particular, with an
+# empty tag the parse location for the start and end is not the same) so I
+# have to take a dom-like approach if I want to identify them. There are a
+# lot of empty tags in svg.  This way I can do some other kinds of cleanup
+# as well (remove unnecessary 'g' elements, for instance).
+
+# Use nodes instead of tuples and strings because it's easier to mutate
+# a tree of these, and cleaner will want to do this.
+
+class _Elem_Node(object):
+  def __init__(self, name, attrs, contents):
+    self.name = name
+    self.attrs = attrs
+    self.contents = contents
+
+  def __repr__(self):
+    line = ["elem(name: '%s'" % self.name]
+    if self.attrs:
+      line.append(" attrs: '%s'" % self.attrs)
+    if self.contents:
+      line.append(" contents[%s]: '%s'" % (len(self.contents), self.contents))
+    line.append(')')
+    return ''.join(line)
+
+class _Text_Node(object):
+  def __init__(self, text):
+    self.text = text
+
+  def __repr__(self):
+    return "text('%s')" % self.text
+
+class SvgCleaner(object):
+  """Strip out unwanted parts of an svg file, primarily the xml declaration and
+  doctype lines, comments, and some attributes of the outermost <svg> element.
+  The id will be replaced when it is inserted into the font.  viewBox causes
+  unwanted scaling when used in a font and its effect is difficult to
+  predict. version is unneeded, xml:space is ignored (we're processing spaces
+  so a request to maintain them has no effect).  enable-background appears to
+  have no effect.  x and y on the outermost svg element have no effect.  We
+  keep width and height, and will elsewhere assume these are the dimensions
+  used for the character box."""
+
+  def __init__(self):
+    self.reader = SvgCleaner._Reader()
+    self.cleaner = SvgCleaner._Cleaner()
+    self.writer = SvgCleaner._Writer()
+
+  class _Reader(object):
+    """Loosely based on fonttools's XMLReader.  This generates a tree of nodes,
+    either element nodes or text nodes.  Successive text content is merged
+    into one node, so contents will never contain more than one _Text_Node in
+    a row.  This drops comments, xml declarations, and doctypes."""
+
+    def _reset(self, parser):
+      self._stack = []
+      self._textbuf = []
+
+    def _start_element(self, name, attrs):
+      self._flush_textbuf()
+      node = _Elem_Node(name, attrs, [])
+      if len(self._stack):
+        self._stack[-1].contents.append(node)
+      self._stack.append(node)
+
+    def _end_element(self, name):
+      self._flush_textbuf()
+      if len(self._stack) > 1:
+        self._stack = self._stack[:-1]
+
+    def _character_data(self, data):
+      if len(self._stack):
+        self._textbuf.append(data)
+
+    def _flush_textbuf(self):
+      if self._textbuf:
+        node = _Text_Node(''.join(self._textbuf))
+        self._stack[-1].contents.append(node)
+        self._textbuf = []
+
+    def from_text(self, data):
+      """Return the root node of a tree representing the svg data."""
+
+      parser = expat.ParserCreate()
+      parser.StartElementHandler = self._start_element
+      parser.EndElementHandler = self._end_element
+      parser.CharacterDataHandler = self._character_data
+      self._reset(parser)
+      parser.Parse(data)
+      return self._stack[0]
+
+  class _Cleaner(object):
+    def _clean_elem(self, node):
+      viewBox, width, height = None, None, None
+      nattrs = {}
+      for k, v in node.attrs.items():
+        if node.name == 'svg' and k in [
+            'x', 'y', 'id', 'version', 'viewBox', 'width', 'height',
+            'enable-background', 'xml:space', 'xmlns:graph', 'xmlns:i',
+            'xmlns:x']:
+          if k == 'viewBox':
+            viewBox = v
+          elif k == 'width':
+            width = v
+          elif k == 'height':
+            height = v
+          elif k.startswith('xmlns:') and 'ns.adobe.com' not in v:
+            # keep if not an adobe namespace
+            logging.debug('keep "%s" = "%s"' % (k, v))
+            nattrs[k] = v
+          logging.debug('removing %s=%s' % (k, v))
+          continue
+        v = re.sub('\s+', ' ', v)
+        nattrs[k] = v
+
+      if node.name == 'svg':
+        if not width or not height:
+          if not viewBox:
+            raise ValueError('no viewBox, width, or height')
+          width, height = viewBox.split()[2:]
+        nattrs['width'] = width
+        nattrs['height'] = height
+      node.attrs = nattrs
+
+      # scan contents. remove any empty text nodes, or empty 'g' element nodes.
+      # if a 'g' element has no attrs and only one subnode, replace it with the
+      # subnode.
+      wpos = 0
+      for n in node.contents:
+        if isinstance(n, _Text_Node):
+          if not n.text:
+            continue
+        elif n.name == 'g':
+          if not n.contents:
+            continue
+          if 'i:extraneous' in n.attrs:
+            del n.attrs['i:extraneous']
+          if not n.attrs and len(n.contents) == 1:
+            n = n.contents[0]
+        elif n.name == 'i:pgf' or n.name == 'foreignObject':
+          continue
+        elif n.name =='switch' and len(n.contents) == 1:
+          n = n.contents[0]
+        elif n.name == 'style':
+          # some emacsen don't default 'style' properly, so leave this in.
+          if False and n.attrs.get('type') == 'text/css':
+            del n.attrs['type']
+
+        node.contents[wpos] = n
+        wpos += 1
+      if wpos < len(node.contents):
+        node.contents = node.contents[:wpos]
+
+    def _clean_text(self, node):
+      text = node.text.strip()
+      # common case is text is empty (line endings between elements)
+      if text:
+        # main goal here is to leave linefeeds in for style elements
+        text = re.sub(r'[ \t]*\n+[ \t]*', '\n', text)
+        text = re.sub(r'[ \t]+', ' ', text)
+      node.text = text
+
+    def clean(self, node):
+      if isinstance(node, _Text_Node):
+        self._clean_text(node)
+      else:
+        # do contents first, so we can check for empty subnodes after
+        for n in node.contents:
+          self.clean(n)
+        self._clean_elem(node)
+
+  class _Writer(object):
+    """For text nodes, replaces sequences of whitespace with a single space.
+    For elements, replaces sequences of whitespace in attributes, and
+    removes unwanted attributes from <svg> elements."""
+
+    def _write_node(self, node, lines, indent):
+      """Node is a node generated by _Reader, either a TextNode or an
+      ElementNode. Lines is a list to collect the lines of output.  Indent is
+      the indentation level for this node."""
+
+      if isinstance(node, _Text_Node):
+        if node.text:
+          lines.append(node.text)
+      else:
+        margin = '  ' * indent
+        line = [margin]
+        line.append('<%s' % node.name)
+        # custom sort attributes of svg, yes this is a hack
+        if node.name == 'svg':
+          def svgsort(k):
+            if k == 'width': return (0, None)
+            elif k == 'height': return (1, None)
+            else: return (2, k)
+          ks = sorted(node.attrs.keys(), key=svgsort)
+        else:
+          def defsort(k):
+            if k == 'id': return (0, None)
+            elif k == 'class': return (1, None)
+            else: return (2, k)
+          ks = sorted(node.attrs.keys(), key=defsort)
+        for k in ks:
+          v = node.attrs[k]
+          line.append(' %s=%s' % (k, saxutils.quoteattr(v)))
+        if node.contents:
+          line.append('>')
+          lines.append(''.join(line))
+          for elem in node.contents:
+            self._write_node(elem, lines, indent + 1)
+          line = [margin]
+          line.append('</%s>' % node.name)
+          lines.append(''.join(line))
+        else:
+          line.append('/>')
+          lines.append(''.join(line))
+
+    def to_text(self, root):
+      # set up lines for recursive calls, let them append lines, then return
+      # the result.
+      lines = []
+      self._write_node(root, lines, 0)
+      return '\n'.join(lines)
+
+  def tree_from_text(self, svg_text):
+    return self.reader.from_text(svg_text)
+
+  def clean_tree(self, svg_tree):
+    self.cleaner.clean(svg_tree)
+
+  def tree_to_text(self, svg_tree):
+    return self.writer.to_text(svg_tree)
+
+  def clean_svg(self, svg_text):
+    """Return the cleaned svg_text."""
+    tree = self.tree_from_text(svg_text)
+    self.clean_tree(tree)
+    return self.tree_to_text(tree)
+
+
+def clean_svg_files(in_dir, out_dir, match_pat=None, clean=False):
+  regex = re.compile(match_pat) if match_pat else None
+  count = 0
+
+  if clean and path.samefile(in_dir, out_dir):
+    logging.error('Cannot clean %s (same as in_dir)', out_dir)
+    return
+
+  out_dir = tool_utils.ensure_dir_exists(out_dir, clean=clean)
+
+  cleaner = SvgCleaner()
+  for file_name in os.listdir(in_dir):
+    if regex and not regex.match(file_name):
+      continue
+    in_path = os.path.join(in_dir, file_name)
+    logging.debug('read: %s', in_path)
+    with open(in_path) as in_fp:
+      result = cleaner.clean_svg(in_fp.read())
+    out_path = os.path.join(out_dir, file_name)
+    with codecs.open(out_path, 'w', 'utf-8') as out_fp:
+      logging.debug('write: %s', out_path)
+      out_fp.write(result)
+      count += 1
+  if not count:
+    logging.warning('Failed to match any files')
+  else:
+    logging.info('Wrote %s files to %s', count, out_dir)
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description="Generate 'cleaned' svg files.")
+  parser.add_argument(
+      'in_dir', help='Input directory.', metavar='dir')
+  parser.add_argument(
+      '-o', '--out_dir', help='Output directory, defaults to sibling of in_dir',
+      metavar='dir')
+  parser.add_argument(
+      '-c', '--clean', help='Clean output directory', action='store_true')
+  parser.add_argument(
+      '-r', '--regex', help='Regex to select files, default matches all files.',
+      metavar='regex', default=None)
+  parser.add_argument(
+      '-l', '--loglevel', help='log level name/value', default='warning')
+  args = parser.parse_args()
+
+  tool_utils.setup_logging(args.loglevel)
+
+  if not args.out_dir:
+    if args.in_dir.endswith('/'):
+      args.in_dir = args.in_dir[:-1]
+    args.out_dir = args.in_dir + '_clean'
+    logging.info('Writing output to %s', args.out_dir)
+
+  clean_svg_files(
+      args.in_dir, args.out_dir, match_pat=args.regex, clean=args.clean)
+
+
+if __name__ == '__main__':
+  main()

--- a/linux/third_party/color_emoji/LICENSE
+++ b/linux/third_party/color_emoji/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2013 Google, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/linux/third_party/color_emoji/README
+++ b/linux/third_party/color_emoji/README
@@ -1,0 +1,13 @@
+This project consists of the following bits and pieces:
+
+  * A proposed specification to add support for embedded color image
+    glyphs in OpenType fonts,
+
+  * A tool called emoji_builder.py, to embed a set of PNG images into
+    an existing font,
+
+  * Two sets of sample PNG images for ASCII characters and sample
+    scripts to build them into test fonts: FruityGirl and Funkster.
+
+  * Scripts to build a real color emoji font out of the Open Source
+    PhantomOpenEmoji images.

--- a/linux/third_party/color_emoji/README.third_party
+++ b/linux/third_party/color_emoji/README.third_party
@@ -1,0 +1,11 @@
+URL: http://color-emoji.googlecode.com/archive/dce2d8ad953a7b03200723f9f1d25121cb45150a.zip
+Version: dce2d8ad953a7b03200723f9f1d25121cb45150a
+License: BSD
+License File: LICENSE
+
+Description:
+Color Emoji font creation tools
+
+Local Modifications:
+COPYING file was renamed to LICENSE.  The samples font sources and the
+specification are not included.

--- a/linux/third_party/color_emoji/emoji_builder.py
+++ b/linux/third_party/color_emoji/emoji_builder.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python
+#
+# Copyright 2013 Google, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Google Author(s): Behdad Esfahbod, Stuart Gill, Roozbeh Pournader
+#
+
+
+from __future__ import print_function
+import sys, struct, StringIO
+from png import PNG
+import os
+from os import path
+
+from nototools import font_data
+
+def get_glyph_name_from_gsub (string, font, cmap_dict):
+	ligatures = font['GSUB'].table.LookupList.Lookup[0].SubTable[0].ligatures
+	first_glyph = cmap_dict[ord (string[0])]
+	rest_of_glyphs = [cmap_dict[ord (ch)] for ch in string[1:]]
+	for ligature in ligatures[first_glyph]:
+		if ligature.Component == rest_of_glyphs:
+			return ligature.LigGlyph
+
+
+def div (a, b):
+	return int (round (a / float (b)))
+
+class FontMetrics:
+	def __init__ (self, upem, ascent, descent):
+		self.upem = upem
+		self.ascent = ascent
+		self.descent = descent
+
+class StrikeMetrics:
+	def __init__ (self, font_metrics, advance, bitmap_width, bitmap_height):
+		self.width = bitmap_width # in pixels
+		self.height = bitmap_height # in pixels
+		self.advance = advance # in font units
+		self.x_ppem = self.y_ppem = div (bitmap_width * font_metrics.upem, advance)
+
+class GlyphMap:
+	def __init__ (self, glyph, offset, image_format):
+		self.glyph = glyph
+		self.offset = offset
+		self.image_format = image_format
+
+
+# Based on http://www.microsoft.com/typography/otspec/ebdt.htm
+class CBDT:
+
+	def __init__ (self, font_metrics, options = (), stream = None):
+		self.stream = stream if stream != None else bytearray ()
+		self.options = options
+		self.font_metrics = font_metrics
+		self.base_offset = 0
+		self.base_offset = self.tell ()
+
+	def tell (self):
+		return len (self.stream) - self.base_offset
+	def write (self, data):
+		self.stream.extend (data)
+	def data (self):
+		return self.stream
+
+	def write_header (self):
+		self.write (struct.pack (">L", 0x00020000)) # FIXED version
+
+	def start_strike (self, strike_metrics):
+		self.strike_metrics = strike_metrics
+		self.glyph_maps = []
+
+	def write_glyphs (self, glyphs, glyph_filenames, image_format):
+
+		write_func = self.image_write_func (image_format)
+		for glyph in glyphs:
+			img_file = glyph_filenames[glyph]
+                        # print 'writing data for glyph %s' % path.basename(img_file)
+			offset = self.tell ()
+			write_func (PNG (img_file))
+			self.glyph_maps.append (GlyphMap (glyph, offset, image_format))
+
+	def end_strike (self):
+
+		self.glyph_maps.append (GlyphMap (None, self.tell (), None))
+		glyph_maps = self.glyph_maps
+		del self.glyph_maps
+		del self.strike_metrics
+		return glyph_maps
+
+	def write_smallGlyphMetrics (self, width, height):
+
+		ascent = self.font_metrics.ascent
+		descent = self.font_metrics.descent
+		upem = self.font_metrics.upem
+		y_ppem = self.strike_metrics.y_ppem
+
+		x_bearing = 0
+		# center vertically
+		line_height = (ascent + descent) * y_ppem / float (upem)
+		line_ascent = ascent * y_ppem / float (upem)
+		y_bearing = int (round (line_ascent - .5 * (line_height - height)))
+                # fudge y_bearing if calculations are a bit off
+                if y_bearing == 128:
+                  y_bearing = 127
+		advance = width
+                # print "small glyph metrics h: %d w: %d" % (height, width)
+		# smallGlyphMetrics
+		# Type	Name
+		# BYTE	height
+		# BYTE	width
+		# CHAR	BearingX
+		# CHAR	BearingY
+		# BYTE	Advance
+                try:
+                        self.write (struct.pack ("BBbbB",
+					 height, width,
+					 x_bearing, y_bearing,
+					 advance))
+                except Exception as e:
+                  raise ValueError("%s, h: %d w: %d x: %d y: %d %d a:" % (
+                      e, height, width, x_bearing, y_bearing, advance))
+
+	def write_format1 (self, png):
+
+		import cairo
+		img = cairo.ImageSurface.create_from_png (png.stream ())
+		if img.get_format () != cairo.FORMAT_ARGB32:
+			raise Exception ("Expected FORMAT_ARGB32, but image has format %d" % img.get_format ())
+
+		width = img.get_width ()
+		height = img.get_height ()
+		stride = img.get_stride ()
+		data = img.get_data ()
+
+		self.write_smallGlyphMetrics (width, height)
+
+		if sys.byteorder == "little" and stride == width * 4:
+			# Sweet.  Data is in desired format, ship it!
+			self.write (data)
+			return
+
+		# Unexpected stride or endianness, do it the slow way
+		offset = 0
+		for y in range (height):
+			for x in range (width):
+				pixel = data[offset + 4 * x: offset + 4 * (x + 1)]
+				# Convert to little endian
+				pixel = struct.pack ("<I", struct.unpack ("@I", pixel)[0])
+				self.write (pixel)
+			offset += stride
+
+	png_allowed_chunks =  ["IHDR", "PLTE", "tRNS", "sRGB", "IDAT", "IEND"]
+
+	def write_format17 (self, png):
+
+		width, height = png.get_size ()
+
+		if 'keep_chunks' not in self.options:
+			png = png.filter_chunks (self.png_allowed_chunks)
+
+		self.write_smallGlyphMetrics (width, height)
+
+		png_data = png.data ()
+		# ULONG data length
+		self.write (struct.pack(">L", len (png_data)))
+		self.write (png_data)
+
+	def image_write_func (self, image_format):
+		if image_format == 1: return self.write_format1
+		if image_format == 17: return self.write_format17
+		return None
+
+
+# Based on http://www.microsoft.com/typography/otspec/eblc.htm
+class CBLC:
+
+	def __init__ (self, font_metrics, options = (), stream = None):
+		self.stream = stream if stream != None else bytearray ()
+		self.streams = []
+		self.options = options
+		self.font_metrics = font_metrics
+		self.base_offset = 0
+		self.base_offset = self.tell ()
+
+	def tell (self):
+		return len (self.stream) - self.base_offset
+	def write (self, data):
+		self.stream.extend (data)
+	def data (self):
+		return self.stream
+	def push_stream (self, stream):
+		self.streams.append (self.stream)
+		self.stream = stream
+	def pop_stream (self):
+		stream = self.stream
+		self.stream = self.streams.pop ()
+		return stream
+
+	def write_header (self):
+		self.write (struct.pack (">L", 0x00020000)) # FIXED version
+
+	def start_strikes (self, num_strikes):
+		self.num_strikes = num_strikes
+		self.write (struct.pack (">L", self.num_strikes)) # ULONG numSizes
+		self.bitmapSizeTables = bytearray ()
+		self.otherTables = bytearray ()
+
+	def write_strike (self, strike_metrics, glyph_maps):
+		self.strike_metrics = strike_metrics
+		self.write_bitmapSizeTable (glyph_maps)
+		del self.strike_metrics
+
+	def end_strikes (self):
+		self.write (self.bitmapSizeTables)
+		self.write (self.otherTables)
+		del self.bitmapSizeTables
+		del self.otherTables
+
+	def write_sbitLineMetrics_hori (self):
+
+		ascent = self.font_metrics.ascent
+		descent = self.font_metrics.descent
+		upem = self.font_metrics.upem
+		y_ppem = self.strike_metrics.y_ppem
+
+		# sbitLineMetrics
+		# Type	Name
+		# CHAR	ascender
+		# CHAR	descender
+		# BYTE	widthMax
+		# CHAR	caretSlopeNumerator
+		# CHAR	caretSlopeDenominator
+		# CHAR	caretOffset
+		# CHAR	minOriginSB
+		# CHAR	minAdvanceSB
+		# CHAR	maxBeforeBL
+		# CHAR	minAfterBL
+		# CHAR	pad1
+		# CHAR	pad2
+		line_height = div ((ascent + descent) * y_ppem, upem)
+		ascent = div (ascent * y_ppem, upem)
+		descent = - (line_height - ascent)
+		self.write (struct.pack ("bbBbbbbbbbbb",
+					 ascent, descent,
+					 self.strike_metrics.width,
+					 0, 0, 0,
+					 0, 0, 0, 0, # TODO
+					 0, 0))
+
+	def write_sbitLineMetrics_vert (self):
+		self.write_sbitLineMetrics_hori () # XXX
+
+	def write_indexSubTable1 (self, glyph_maps):
+
+		image_format = glyph_maps[0].image_format
+
+		self.write (struct.pack(">H", 1)) # USHORT indexFormat
+		self.write (struct.pack(">H", image_format)) # USHORT imageFormat
+		imageDataOffset = glyph_maps[0].offset
+		self.write (struct.pack(">L", imageDataOffset)) # ULONG imageDataOffset
+		for gmap in glyph_maps[:-1]:
+			self.write (struct.pack(">L", gmap.offset - imageDataOffset)) # ULONG offsetArray
+			assert gmap.image_format == image_format
+		self.write (struct.pack(">L", glyph_maps[-1].offset - imageDataOffset))
+
+	def write_bitmapSizeTable (self, glyph_maps):
+
+		# count number of ranges
+		count = 1
+		start = glyph_maps[0].glyph
+		last_glyph = start
+		last_image_format = glyph_maps[0].image_format
+		for gmap in glyph_maps[1:-1]:
+			if last_glyph + 1 != gmap.glyph or last_image_format != gmap.image_format:
+				count += 1
+			last_glyph = gmap.glyph
+			last_image_format = gmap.image_format
+		headersLen = count * 8
+
+		headers = bytearray ()
+		subtables = bytearray ()
+		start = glyph_maps[0].glyph
+		start_id = 0
+		last_glyph = start
+		last_image_format = glyph_maps[0].image_format
+		last_id = 0
+		for gmap in glyph_maps[1:-1]:
+			if last_glyph + 1 != gmap.glyph or last_image_format != gmap.image_format:
+				headers.extend (struct.pack(">HHL", start, last_glyph, headersLen + len (subtables)))
+				self.push_stream (subtables)
+				self.write_indexSubTable1 (glyph_maps[start_id:last_id+2])
+				self.pop_stream ()
+
+				start = gmap.glyph
+				start_id = last_id + 1
+			last_glyph = gmap.glyph
+			last_image_format = gmap.image_format
+			last_id += 1
+		headers.extend (struct.pack(">HHL", start, last_glyph, headersLen + len (subtables)))
+		self.push_stream (subtables)
+		self.write_indexSubTable1 (glyph_maps[start_id:last_id+2])
+		self.pop_stream ()
+
+		indexTablesSize = len (headers) + len (subtables)
+		numberOfIndexSubTables = count
+		bitmapSizeTableSize = 48 * self.num_strikes
+
+		indexSubTableArrayOffset = 8 + bitmapSizeTableSize + len (self.otherTables)
+
+		self.push_stream (self.bitmapSizeTables)
+		# bitmapSizeTable
+		# Type	Name	Description
+		# ULONG	indexSubTableArrayOffset	offset to index subtable from beginning of CBLC.
+		self.write (struct.pack(">L", indexSubTableArrayOffset))
+		# ULONG	indexTablesSize	number of bytes in corresponding index subtables and array
+		self.write (struct.pack(">L", indexTablesSize))
+		# ULONG	numberOfIndexSubTables	an index subtable for each range or format change
+		self.write (struct.pack(">L", numberOfIndexSubTables))
+		# ULONG	colorRef	not used; set to 0.
+		self.write (struct.pack(">L", 0))
+		# sbitLineMetrics	hori	line metrics for text rendered horizontally
+		self.write_sbitLineMetrics_hori ()
+		self.write_sbitLineMetrics_vert ()
+		# sbitLineMetrics	vert	line metrics for text rendered vertically
+		# USHORT	startGlyphIndex	lowest glyph index for this size
+		self.write (struct.pack(">H", glyph_maps[0].glyph))
+		# USHORT	endGlyphIndex	highest glyph index for this size
+		self.write (struct.pack(">H", glyph_maps[-2].glyph))
+		# BYTE	ppemX	horizontal pixels per Em
+		self.write (struct.pack(">B", self.strike_metrics.x_ppem))
+		# BYTE	ppemY	vertical pixels per Em
+		self.write (struct.pack(">B", self.strike_metrics.y_ppem))
+		# BYTE	bitDepth	the Microsoft rasterizer v.1.7 or greater supports the
+		#			following bitDepth values, as described below: 1, 2, 4, and 8.
+		self.write (struct.pack(">B", 32))
+		# CHAR	flags	vertical or horizontal (see bitmapFlags)
+		self.write (struct.pack(">b", 0x01))
+		self.pop_stream ()
+
+		self.push_stream (self.otherTables)
+		self.write (headers)
+		self.write (subtables)
+		self.pop_stream ()
+
+
+def main (argv):
+	import glob
+	from fontTools import ttx, ttLib
+
+	options = []
+
+	option_map = {
+		"-V": "verbose",
+		"-O": "keep_outlines",
+		"-U": "uncompressed",
+		"-C": "keep_chunks",
+	}
+
+	for key, value in option_map.items ():
+		if key in argv:
+			options.append (value)
+			argv.remove (key)
+
+	if len (argv) < 4:
+		print("""
+Usage:
+
+emoji_builder.py [-V] [-O] [-U] [-A] font.ttf out-font.ttf strike-prefix...
+
+This will search for files that have strike-prefix followed
+by a hex number, and end in ".png".  For example, if strike-prefix
+is "icons/uni", then files with names like "icons/uni1f4A9.png" will
+be loaded.  All images for the same strike should have the same size
+for best results.
+
+If multiple strike-prefix parameters are provided, multiple
+strikes will be embedded, in the order provided.
+
+The script then embeds color bitmaps in the font, for characters
+that the font already supports, and writes the new font out.
+
+If -V is given, verbose mode is enabled.
+
+If -U is given, uncompressed images are stored (imageFormat=1).
+By default, PNG images are stored (imageFormat=17).
+
+If -O is given, the outline tables ('glyf', 'CFF ') and
+related tables are NOT dropped from the font.
+By default they are dropped.
+
+If -C is given, unused chunks (color profile, etc) are NOT
+dropped from the PNG images when embedding.
+By default they are dropped.
+""", file=sys.stderr)
+		sys.exit (1)
+
+	font_file = argv[1]
+	out_file = argv[2]
+	img_prefixes = argv[3:]
+	del argv
+
+	def add_font_table (font, tag, data):
+		tab = ttLib.tables.DefaultTable.DefaultTable (tag)
+		tab.data = str(data)
+		font[tag] = tab
+
+	def drop_outline_tables (font):
+		for tag in ['cvt ', 'fpgm', 'glyf', 'loca', 'prep', 'CFF ', 'VORG']:
+			try:
+				del font[tag]
+			except KeyError:
+				pass
+
+
+	print()
+
+	font = ttx.TTFont (font_file)
+	print("Loaded font '%s'." % font_file)
+
+	font_metrics = FontMetrics (font['head'].unitsPerEm,
+				    font['hhea'].ascent,
+				    -font['hhea'].descent)
+	print("Font metrics: upem=%d ascent=%d descent=%d." % \
+	      (font_metrics.upem, font_metrics.ascent, font_metrics.descent))
+	glyph_metrics = font['hmtx'].metrics
+	unicode_cmap = font['cmap'].getcmap (3, 10)
+	if not unicode_cmap:
+		unicode_cmap = font['cmap'].getcmap (3, 1)
+	if not unicode_cmap:
+		raise Exception ("Failed to find a Unicode cmap.")
+
+	image_format = 1 if 'uncompressed' in options else 17
+
+	ebdt = CBDT (font_metrics, options)
+	ebdt.write_header ()
+	eblc = CBLC (font_metrics, options)
+	eblc.write_header ()
+	eblc.start_strikes (len (img_prefixes))
+
+        def is_vs(cp):
+                return cp >= 0xfe00 and cp <= 0xfe0f
+
+	for img_prefix in img_prefixes:
+		print()
+
+		img_files = {}
+		glb = "%s*.png" % img_prefix
+		print("Looking for images matching '%s'." % glb)
+		for img_file in glob.glob (glb):
+			codes = img_file[len (img_prefix):-4]
+			if "_" in codes:
+				pieces = codes.split ("_")
+                                cps = [int(code, 16) for code in pieces]
+				uchars = "".join ([unichr(cp) for cp in cps if not is_vs(cp)])
+			else:
+                                cp = int(codes, 16)
+                                if is_vs(cp):
+                                        print("ignoring unexpected vs input %04x" % cp)
+                                        continue
+				uchars = unichr(cp)
+			img_files[uchars] = img_file
+		if not img_files:
+			raise Exception ("No image files found in '%s'." % glb)
+		print("Found images for %d characters in '%s'." % (len (img_files), glb))
+
+		glyph_imgs = {}
+		advance = width = height = 0
+		for uchars, img_file in img_files.items ():
+			if len (uchars) == 1:
+                                try:
+                                        glyph_name = unicode_cmap.cmap[ord (uchars)]
+                                except:
+                                        print("no cmap entry for %x" % ord(uchars))
+                                        raise ValueError("%x" % ord(uchars))
+			else:
+				glyph_name = get_glyph_name_from_gsub (uchars, font, unicode_cmap.cmap)
+			glyph_id = font.getGlyphID (glyph_name)
+			glyph_imgs[glyph_id] = img_file
+			if "verbose" in options:
+				uchars_name = ",".join (["%04X" % ord (char) for char in uchars])
+				# print "Matched U+%s: id=%d name=%s image=%s" % (
+                                #    uchars_name, glyph_id, glyph_name, img_file)
+
+			advance += glyph_metrics[glyph_name][0]
+			w, h = PNG (img_file).get_size ()
+			width += w
+			height += h
+
+		glyphs = sorted (glyph_imgs.keys ())
+		if not glyphs:
+			raise Exception ("No common characters found between font and '%s'." % glb)
+		print("Embedding images for %d glyphs for this strike." % len (glyphs))
+
+		advance, width, height = (div (x, len (glyphs)) for x in (advance, width, height))
+		strike_metrics = StrikeMetrics (font_metrics, advance, width, height)
+		print("Strike ppem set to %d." % (strike_metrics.y_ppem))
+
+		ebdt.start_strike (strike_metrics)
+		ebdt.write_glyphs (glyphs, glyph_imgs, image_format)
+		glyph_maps = ebdt.end_strike ()
+
+		eblc.write_strike (strike_metrics, glyph_maps)
+
+	print()
+
+	ebdt = ebdt.data ()
+	add_font_table (font, 'CBDT', ebdt)
+	print("CBDT table synthesized: %d bytes." % len (ebdt))
+	eblc.end_strikes ()
+	eblc = eblc.data ()
+	add_font_table (font, 'CBLC', eblc)
+	print("CBLC table synthesized: %d bytes." % len (eblc))
+
+	print()
+
+	if 'keep_outlines' not in options:
+		drop_outline_tables (font)
+		print("Dropped outline ('glyf', 'CFF ') and related tables.")
+
+        # hack removal of cmap pua entry for unknown flag glyph.  If we try to
+        # remove it earlier, getGlyphID dies.  Need to restructure all of this
+        # code.
+        font_data.delete_from_cmap(font, [0xfe82b])
+
+	font.save (out_file)
+	print("Output font '%s' generated." % out_file)
+
+
+if __name__ == '__main__':
+	main (sys.argv)

--- a/linux/third_party/color_emoji/png.py
+++ b/linux/third_party/color_emoji/png.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#
+# Copyright 2013 Google, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Google Author(s): Behdad Esfahbod
+#
+
+import struct, StringIO
+
+
+class PNG:
+
+	signature = bytearray ((137,80,78,71,13,10,26,10))
+
+	def __init__ (self, f):
+
+		if isinstance(f, basestring):
+			f = open (f, 'rb')
+
+		self.f = f
+		self.IHDR = None
+
+	def tell (self):
+		return self.f.tell ()
+
+	def seek (self, pos):
+		self.f.seek (pos)
+
+	def stream (self):
+		return self.f
+
+	def data (self):
+		self.seek (0)
+		return bytearray (self.f.read ())
+
+	class BadSignature (Exception): pass
+	class BadChunk (Exception): pass
+
+	def read_signature (self):
+		header = bytearray (self.f.read (8))
+		if header != PNG.signature:
+			raise PNG.BadSignature
+		return PNG.signature
+
+	def read_chunk (self):
+		length = struct.unpack (">I", self.f.read (4))[0]
+		chunk_type = self.f.read (4)
+		chunk_data = self.f.read (length)
+		if len (chunk_data) != length:
+			raise PNG.BadChunk
+		crc = self.f.read (4)
+		if len (crc) != 4:
+			raise PNG.BadChunk
+		return (chunk_type, chunk_data, crc)
+
+	def read_IHDR (self):
+		(chunk_type, chunk_data, crc) = self.read_chunk ()
+		if chunk_type != "IHDR":
+			raise PNG.BadChunk
+		#  Width:              4 bytes
+		#  Height:             4 bytes
+		#  Bit depth:          1 byte
+		#  Color type:         1 byte
+		#  Compression method: 1 byte
+		#  Filter method:      1 byte
+		#  Interlace method:   1 byte
+		return struct.unpack (">IIBBBBB", chunk_data)
+
+	def read_header (self):
+		self.read_signature ()
+		self.IHDR = self.read_IHDR ()
+		return self.IHDR
+
+	def get_size (self):
+		if not self.IHDR:
+			pos = self.tell ()
+			self.seek (0)
+			self.read_header ()
+			self.seek (pos)
+		return self.IHDR[0:2]
+
+	def filter_chunks (self, chunks):
+		self.seek (0);
+		out = StringIO.StringIO ()
+		out.write (self.read_signature ())
+		while True:
+			chunk_type, chunk_data, crc = self.read_chunk ()
+			if chunk_type in chunks:
+				out.write (struct.pack (">I", len (chunk_data)))
+				out.write (chunk_type)
+				out.write (chunk_data)
+				out.write (crc)
+			if chunk_type == "IEND":
+				break
+		return PNG (out)


### PR DESCRIPTION
Emoji One provides a font file named emojione-android.ttf. But the font also works on (very recent) Linux distributions using GNOME (or similar desktops). I don't know how the "Android" font version was built historically (the build system isn't specificied in the git repo) but I believe it is currently built using https://github.com/mxalbert1996/emojione-android/ which makes a few tweaks to the buildsystem provided by [Noto Emoji](https://github.com/googlei18n/noto-emoji/).

It would be nice if Google would move the buildsystem part of Noto Emoji to a separate project from the Noto Emoji font sources. See https://github.com/googlei18n/noto-emoji/issues/9 but for now, I think this is the way we need to do it.

I used a separate directory for this to make the licensing easier to understand and to make it easier to compare with upstream Noto Emoji. The Linux buildsystem is licensed Apache-2.0.